### PR TITLE
fixes up to CTLG 1.0 2026-04-14-2032

### DIFF
--- a/Arcana/chargen/scenarios.json
+++ b/Arcana/chargen/scenarios.json
@@ -89,7 +89,6 @@
     "type": "scenario",
     "id": "surrounded",
     "copy-from": "surrounded",
-    "add_professions": true,
     "extend": {
       "professions": [
         "arcanist_alchemist",
@@ -107,7 +106,6 @@
     "type": "scenario",
     "id": "isolationist",
     "copy-from": "isolationist",
-    "add_professions": true,
     "extend": {
       "professions": [
         "arcanist_alchemist",
@@ -206,46 +204,6 @@
         "MARTIAL_ARTS_CF"
       ]
     }
-  },
-  {
-    "type": "scenario",
-    "id": "wilderness",
-    "copy-from": "wilderness",
-    "add_professions": true,
-    "extend": {
-      "professions": [
-        "arcanist_alchemist",
-        "arcanist_scribe",
-        "arcanist_bloodmage",
-        "arcanist_magehunter",
-        "arcanist_dark_priest",
-        "arcanist_summoner"
-      ],
-      "traits": [ "MARTIAL_ARTS_SANGUINE", "MARTIAL_ARTS_CF" ]
-    }
-  },
-  {
-    "type": "scenario",
-    "id": "strong_portal_storm",
-    "copy-from": "strong_portal_storm",
-    "add_professions": true,
-    "extend": {
-      "professions": [
-        "arcanist_alchemist",
-        "arcanist_scribe",
-        "arcanist_bloodmage",
-        "arcanist_magehunter",
-        "arcanist_dark_priest",
-        "arcanist_summoner"
-      ]
-    }
-  },
-  {
-    "type": "scenario",
-    "id": "portal_dependent",
-    "copy-from": "portal_dependent",
-    "add_professions": true,
-    "extend": { "professions": [ "arcanist_bloodmage", "arcanist_dragonblood_aspirant", "arcanist_shrike", "arcanist_summoner" ] }
   },
   {
     "type": "scenario",

--- a/Arcana/furniture_and_terrain/furniture.json
+++ b/Arcana/furniture_and_terrain/furniture.json
@@ -184,7 +184,7 @@
     "name": "shimmering barrier",
     "description": "A strange wavering distortion in the air, offering the faintest hint of illumination.  It hardens into a crackling wall of light when struck, examining it will allow you to dismiss it.",
     "symbol": "#",
-    "looks_like": "t_reinforced_glass",
+    "looks_like": "t_laminated_glass",
     "bgcolor": [ "blue" ],
     "move_cost_mod": -2,
     "light_emitted": 1,
@@ -231,7 +231,7 @@
       "items": [ { "item": "transmutation_crucible", "prob": 75 }, { "item": "rock", "count": [ 2, 7 ] } ]
     },
     "examine_action": "workbench",
-    "workbench": { "multiplier": 1.05, "mass": 500000, "volume": "500L" }
+    "workbench": { "multiplier": 1.05, "mass": "500000 g", "volume": "500L" }
   },
   {
     "id": "f_arcana_dimension_doorway",

--- a/Arcana/item_groups/item_groups_vanilla.json
+++ b/Arcana/item_groups/item_groups_vanilla.json
@@ -83,8 +83,8 @@
     "extend": { "entries": [ { "group": "magic_books", "prob": 15 } ] }
   },
   {
-    "id": "rare_martial_arts_books",
-    "copy-from": "rare_martial_arts_books",
+    "id": "exotic_books",
+    "copy-from": "exotic_books",
     "type": "item_group",
     "subtype": "distribution",
     "extend": { "entries": [ { "item": "manual_cleansingflame", "prob": 1 }, { "item": "manual_shrike", "prob": 1 } ] }
@@ -199,8 +199,8 @@
     }
   },
   {
-    "id": "hive_center",
-    "copy-from": "hive_center",
+    "id": "hive",
+    "copy-from": "hive",
     "type": "item_group",
     "extend": { "items": [ [ "dermatik_sting", 1 ] ] }
   },
@@ -248,21 +248,6 @@
     }
   },
   {
-    "id": "spider",
-    "copy-from": "spider",
-    "type": "item_group",
-    "subtype": "distribution",
-    "extend": {
-      "entries": [
-        { "item": "arcanemap", "prob": 5 },
-        { "group": "magic_tools", "prob": 1 },
-        { "group": "magic_items", "prob": 1 },
-        { "group": "magic_consumables", "prob": 1 },
-        { "group": "magic_books_postapoc", "prob": 1 }
-      ]
-    }
-  },
-  {
     "id": "drugdealer",
     "copy-from": "drugdealer",
     "type": "item_group",
@@ -287,22 +272,6 @@
     "copy-from": "teleport",
     "type": "item_group",
     "extend": { "items": [ [ "tindalos_whistle", 5 ], [ "recipe_lab_arcana", 7 ] ] }
-  },
-  {
-    "id": "rare",
-    "copy-from": "rare",
-    "type": "item_group",
-    "subtype": "distribution",
-    "extend": {
-      "entries": [
-        { "group": "magic_books_postapoc", "prob": 5 },
-        { "group": "magic_consumables", "prob": 2 },
-        { "group": "magic_tools", "prob": 2 },
-        { "group": "magic_items", "prob": 1 },
-        { "item": "tindalos_whistle", "prob": 10 },
-        { "item": "spatial_displacer", "prob": 5 }
-      ]
-    }
   },
   {
     "id": "museum_misc",
@@ -351,48 +320,10 @@
     }
   },
   {
-    "id": "bionics_op",
-    "copy-from": "bionics_op",
-    "type": "item_group",
-    "extend": {
-      "items": [ [ "bio_electrothermal_arc_projector", 1 ], [ "bio_rift_focus_projector", 1 ], [ "bio_temporal_stimulation", 2 ] ]
-    }
-  },
-  {
-    "id": "bionics_op2_off",
-    "copy-from": "bionics_op2_off",
-    "type": "item_group",
-    "extend": { "items": [ [ "bio_electrothermal_arc_projector", 3 ], [ "bio_rift_focus_projector", 2 ] ] }
-  },
-  {
-    "id": "bionics_op2_def",
-    "copy-from": "bionics_op2_def",
-    "type": "item_group",
-    "extend": { "items": [ [ "bio_life_sign_suppression", 5 ] ] }
-  },
-  {
-    "id": "bionics_op2_utl",
-    "copy-from": "bionics_op2_utl",
-    "type": "item_group",
-    "extend": { "items": [ [ "bio_temporal_stimulation", 4 ] ] }
-  },
-  {
     "type": "item_group",
     "id": "roof_holdout",
     "copy-from": "roof_holdout",
     "extend": { "items": [ { "group": "magic_books_postapoc", "prob": 5 }, { "group": "arcana_hunt_random", "prob": 15 } ] }
-  },
-  {
-    "type": "item_group",
-    "id": "flt_loot_rare",
-    "copy-from": "flt_loot_rare",
-    "extend": { "items": [ { "group": "magic_books_postapoc", "prob": 5 }, { "group": "arcana_hunt_random", "prob": 10 } ] }
-  },
-  {
-    "type": "item_group",
-    "id": "oa_ig_sb_rare",
-    "copy-from": "oa_ig_sb_rare",
-    "extend": { "items": [ { "group": "magic_books_postapoc", "prob": 10 }, { "group": "arcana_hunt_random", "prob": 15 } ] }
   },
   {
     "type": "item_group",

--- a/Arcana/items/magazine.json
+++ b/Arcana/items/magazine.json
@@ -2,43 +2,23 @@
   {
     "id": "arcana_mech_power_cell",
     "type": "ITEM",
-    "subtypes": [
-      "MAGAZINE"
-    ],
+    "subtypes": [ "MAGAZINE" ],
     "category": "spare_parts",
-    "name": {
-      "str": "essence amplification cell"
-    },
+    "name": { "str": "essence amplification cell" },
     "description": "A bespoke power cell designed specifically for a rare and valuable type of prototype mech, using anomalous technology to burn exotic energy sources, with spatial anomaly technology in the machine itself massively increasing efficiency.  Even then, it requires a lot of esoteric essence to make each power cell, and they need to be taken apart and remade once depleted.",
     "weight": "10 kg",
     "volume": "6 L",
     "price": "1000 USD",
     "price_postapoc": "50 USD",
-    "material": [
-      "steel"
-    ],
+    "material": [ "steel" ],
     "symbol": "=",
     "color": "light_cyan",
-    "ammo_type": [
-      "battery"
-    ],
+    "ammo_type": [ "battery" ],
     "//": "Ten crystallized essence at 1500 kJ each, essence surge generator doubles output, distortion amp doubles output again, temporal stimulation effectively halves consumption.",
     "count": 120000,
     "capacity": 120000,
     "looks_like": "battery",
-    "flags": [
-      "NO_SALVAGE",
-      "NO_UNLOAD",
-      "MECH_BAT"
-    ],
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "battery": 120000
-        }
-      }
-    ]
+    "flags": [ "NO_SALVAGE", "NO_UNLOAD", "BATTERY_HEAVY" ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 120000 } } ]
   }
 ]

--- a/Arcana/items/ranged.json
+++ b/Arcana/items/ranged.json
@@ -2,66 +2,32 @@
   {
     "id": "thunder_sigil",
     "type": "ITEM",
-    "subtypes": [
-      "GUN",
-      "ARTIFACT"
-    ],
+    "subtypes": [ "GUN", "ARTIFACT" ],
     "category": "weapons",
-    "name": {
-      "str": "symbol of judgment",
-      "str_pl": "symbols of judgment"
-    },
+    "name": { "str": "symbol of judgment", "str_pl": "symbols of judgment" },
     "description": "A golden band decorated with a trident motif, and inlaid with silver.  Just small enough to grasp the band in your palm, prongs between the fingers.  Holding it gives you the vague sense that this is a holy symbol, dedicated to something not of this world.  Firing it calls forth lightning.",
     "weight": "1100 g",
     "volume": "750 ml",
     "longest_side": "21 cm",
     "price": "1500 USD",
     "price_postapoc": "100 USD",
-    "melee_damage": {
-      "bash": 8,
-      "stab": 10
-    },
-    "material": [
-      "gold",
-      "silver"
-    ],
+    "melee_damage": { "bash": 8, "stab": 10 },
+    "material": [ "gold", "silver" ],
     "symbol": ",",
     "looks_like": "gold_bracelet",
     "color": "yellow",
     "ammo": "essence_type",
     "skill": "magic",
     "range": 50,
-    "ranged_damage": {
-      "damage_type": "electric",
-      "amount": 120,
-      "armor_penetration": 15
-    },
+    "ranged_damage": { "damage_type": "electric", "amount": 120, "armor_penetration": 15 },
     "dispersion": 200,
     "durability": 10,
     "loudness": 150,
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "essence_type": 5
-        }
-      }
-    ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_type": 5 } } ],
     "clip_size": 5,
     "reload": 400,
-    "ammo_effects": [
-      "LIGHTNING",
-      "LIGHTNING_JUDGMENT"
-    ],
-    "flags": [
-      "BELT_CLIP",
-      "NEVER_JAMS",
-      "PRIMITIVE_RANGED_WEAPON",
-      "MAGIC_FOCUS",
-      "TRADER_KEEP_EQUIPPED",
-      "NO_TURRET"
-    ],
+    "ammo_effects": [ "LIGHTNING", "LIGHTNING_JUDGMENT" ],
+    "flags": [ "BELT_CLIP", "NEVER_JAMS", "PRIMITIVE_RANGED_WEAPON", "MAGIC_FOCUS", "TRADER_KEEP_EQUIPPED", "NO_TURRET" ],
     "use_action": "MEDITATE",
     "passive_effects": [
       {
@@ -81,18 +47,10 @@
   {
     "id": "bloodscourge",
     "type": "ITEM",
-    "subtypes": [
-      "GUN",
-      "ARTIFACT"
-    ],
+    "subtypes": [ "GUN", "ARTIFACT" ],
     "category": "weapons",
-    "weapon_category": [
-      "QUARTERSTAVES"
-    ],
-    "name": {
-      "str": "hellfire staff",
-      "str_pl": "hellfire staves"
-    },
+    "weapon_category": [ "QUARTERSTAVES" ],
+    "name": { "str": "hellfire staff", "str_pl": "hellfire staves" },
     "description": "A staff decorated with silver and a skull motif, capped with a strange red gem.  The metal parts feel uncomfortably warm to the touch.  Firing it projects a gout of wicked flame.  It can also be used to spark magical flames, but this will drain fatigue to use.",
     "weight": "2800 g",
     "volume": "3 L",
@@ -100,67 +58,25 @@
     "price": "600 USD",
     "price_postapoc": "75 USD",
     "to_hit": 3,
-    "melee_damage": {
-      "bash": 21
-    },
-    "material": [
-      "wood",
-      "silver",
-      "bone"
-    ],
+    "melee_damage": { "bash": 21 },
+    "material": [ "wood", "silver", "bone" ],
     "symbol": "/",
     "looks_like": "q_staff",
     "color": "red",
     "ammo": "essence_blood_type",
     "skill": "magic",
     "range": 20,
-    "ranged_damage": {
-      "damage_type": "heat",
-      "amount": 40,
-      "armor_penetration": 3
-    },
+    "ranged_damage": { "damage_type": "heat", "amount": 40, "armor_penetration": 3 },
     "dispersion": 250,
     "durability": 10,
     "loudness": 100,
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "essence_blood_type": 15
-        }
-      }
-    ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_blood_type": 15 } } ],
     "clip_size": 15,
     "reload": 300,
-    "modes": [
-      [
-        "DEFAULT",
-        "single",
-        1
-      ],
-      [
-        "BURST",
-        "triple",
-        3
-      ]
-    ],
-    "ammo_effects": [
-      "FLAME",
-      "STREAM",
-      "IGNITE"
-    ],
-    "techniques": [
-      "WBLOCK_1",
-      "RAPID"
-    ],
-    "use_action": {
-      "type": "cast_spell",
-      "spell_id": "arcana_item_sparks",
-      "no_fail": true,
-      "level": 0,
-      "need_wielding": true
-    },
+    "modes": [ [ "DEFAULT", "single", 1 ], [ "BURST", "triple", 3 ] ],
+    "ammo_effects": [ "FLAME", "STREAM", "IGNITE" ],
+    "techniques": [ "WBLOCK_1", "RAPID" ],
+    "use_action": { "type": "cast_spell", "spell_id": "arcana_item_sparks", "no_fail": true, "level": 0, "need_wielding": true },
     "flags": [
       "NEVER_JAMS",
       "DURABLE_MELEE",
@@ -191,16 +107,10 @@
     "id": "shrike_misericorde_folded",
     "looks_like": "pistol_flintlock",
     "type": "ITEM",
-    "subtypes": [
-      "GUN",
-      "ARTIFACT"
-    ],
+    "subtypes": [ "GUN", "ARTIFACT" ],
     "category": "weapons",
     "reload_noise_volume": 10,
-    "name": {
-      "str": "shrike's misericorde (pistol)",
-      "str_pl": "shrike's misericordes (pistol)"
-    },
+    "name": { "str": "shrike's misericorde (pistol)", "str_pl": "shrike's misericordes (pistol)" },
     "description": "An ornate silver weapon combining two flintlock barrels with a thin blade.  It's folded into its more compact pistol form, allowing it to be loaded and fired.  Its shots are imbued with a deathly chill.  The damage it adds to shots can ignore mundane armor, but robots and certain otherworldly monsters will only suffer the bullet's regular damage.  Activate it to revert back to blade form, making it better suited for melee but preventing you from being able to load or fire it.",
     "weight": "2 kg",
     "volume": "500 ml",
@@ -208,80 +118,25 @@
     "price": "1000 USD",
     "price_postapoc": "50 USD",
     "to_hit": -1,
-    "melee_damage": {
-      "bash": 12,
-      "stab": 8
-    },
-    "material": [
-      "iron",
-      "silver"
-    ],
+    "melee_damage": { "bash": 12, "stab": 8 },
+    "material": [ "iron", "silver" ],
     "symbol": "(",
     "color": "light_gray",
-    "ammo": [
-      "flintlock"
-    ],
+    "ammo": [ "flintlock" ],
     "skill": "pistol",
     "range": 2,
-    "ranged_damage": {
-      "damage_type": "cold",
-      "amount": 10
-    },
+    "ranged_damage": { "damage_type": "cold", "amount": 10 },
     "dispersion": 700,
     "durability": 6,
     "blackpowder_tolerance": 96,
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "flintlock": 2
-        }
-      }
-    ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "flintlock": 2 } } ],
     "reload": 700,
-    "modes": [
-      [
-        "DEFAULT",
-        "single",
-        1
-      ],
-      [
-        "DOUBLE",
-        "double",
-        2
-      ]
-    ],
-    "techniques": [
-      "WBLOCK_1"
-    ],
-    "qualities": [
-      [
-        "CUT",
-        1
-      ],
-      [
-        "CUT_FINE",
-        1
-      ],
-      [
-        "BUTCHER",
-        9
-      ]
-    ],
+    "modes": [ [ "DEFAULT", "single", 1 ], [ "DOUBLE", "double", 2 ] ],
+    "techniques": [ "WBLOCK_1" ],
+    "qualities": [ [ "CUT", 1 ], [ "CUT_FINE", 1 ], [ "BUTCHER", 9 ] ],
     "//": "NON_FOULING because transforming it to blade mode already resets fouling.",
-    "flags": [
-      "NEVER_JAMS",
-      "DURABLE_MELEE",
-      "NO_SALVAGE",
-      "RELOAD_ONE",
-      "NO_UNLOAD",
-      "NON_FOULING",
-      "NEEDS_NO_LUBE"
-    ],
-    "ammo_effects": [
-      "ARCANA_SHRIKE_COLD_BULLET"
-    ],
+    "flags": [ "NEVER_JAMS", "DURABLE_MELEE", "NO_SALVAGE", "RELOAD_ONE", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE" ],
+    "ammo_effects": [ "ARCANA_SHRIKE_COLD_BULLET" ],
     "use_action": {
       "menu_text": "Unfold into blade mode",
       "type": "transform",
@@ -308,13 +163,9 @@
   {
     "id": "ethereal_crossbow",
     "type": "ITEM",
-    "subtypes": [
-      "GUN"
-    ],
+    "subtypes": [ "GUN" ],
     "category": "weapons",
-    "name": {
-      "str": "wraithslayer crossbow"
-    },
+    "name": { "str": "wraithslayer crossbow" },
     "description": "A crossbow decorated with golden symbols, seemingly lacking a bowstring.  Instead it propels bright green bolts of energy with high armor penetration.",
     "weight": "2928 g",
     "volume": "1500 ml",
@@ -322,155 +173,62 @@
     "price": "450 USD",
     "price_postapoc": "80 USD",
     "to_hit": 1,
-    "melee_damage": {
-      "bash": 11
-    },
-    "material": [
-      "steel",
-      "wood",
-      "gold"
-    ],
+    "melee_damage": { "bash": 11 },
+    "material": [ "steel", "wood", "gold" ],
     "symbol": "(",
     "looks_like": "crossbow",
     "color": "green",
     "ammo": "essence_dull_type",
     "skill": "rifle",
     "range": 30,
-    "ranged_damage": {
-      "damage_type": "stab",
-      "amount": 60,
-      "armor_penetration": 25
-    },
+    "ranged_damage": { "damage_type": "stab", "amount": 60, "armor_penetration": 25 },
     "dispersion": 150,
     "durability": 6,
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "essence_dull_type": 60
-        }
-      }
-    ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_dull_type": 60 } } ],
     "clip_size": 60,
     "reload": 160,
-    "ammo_effects": [
-      "WIDE",
-      "LASER",
-      "BEANBAG",
-      "BLINDS_EYES"
-    ],
-    "flags": [
-      "NEVER_JAMS",
-      "PRIMITIVE_RANGED_WEAPON",
-      "NO_SALVAGE",
-      "TRADER_KEEP_EQUIPPED"
-    ],
+    "ammo_effects": [ "WIDE", "LASER", "BEANBAG", "BLINDS_EYES" ],
+    "flags": [ "NEVER_JAMS", "PRIMITIVE_RANGED_WEAPON", "NO_SALVAGE", "TRADER_KEEP_EQUIPPED" ],
     "ammo_to_fire": 15,
-    "valid_mod_locations": [
-      [
-        "sling",
-        1
-      ],
-      [
-        "rail mount",
-        1
-      ],
-      [
-        "sights mount",
-        1
-      ],
-      [
-        "underbarrel mount",
-        1
-      ]
-    ]
+    "valid_mod_locations": [ [ "sling", 1 ], [ "rail mount", 1 ], [ "sights mount", 1 ], [ "underbarrel mount", 1 ] ]
   },
   {
     "id": "ethereal_hand_crossbow",
     "type": "ITEM",
-    "subtypes": [
-      "GUN"
-    ],
+    "subtypes": [ "GUN" ],
     "category": "weapons",
-    "name": {
-      "str": "wraithslayer pistol crossbow"
-    },
+    "name": { "str": "wraithslayer pistol crossbow" },
     "description": "A pistol crossbow decorated with golden symbols and lacking a bowstring, instead propelling bright green bolts of energy with high armor penetration.  While less effective than its full-sized counterpart, it still packs quite a punch and consumes less essence to fire.",
     "weight": "1100 g",
     "volume": "500 ml",
     "longest_side": "45 cm",
     "price": "400 USD",
     "price_postapoc": "60 USD",
-    "melee_damage": {
-      "bash": 6
-    },
-    "material": [
-      "steel",
-      "plastic",
-      "gold"
-    ],
+    "melee_damage": { "bash": 6 },
+    "material": [ "steel", "plastic", "gold" ],
     "symbol": "(",
     "looks_like": "crossbow",
     "color": "green",
     "ammo": "essence_dull_type",
     "skill": "pistol",
     "range": 15,
-    "ranged_damage": {
-      "damage_type": "stab",
-      "amount": 40,
-      "armor_penetration": 20
-    },
+    "ranged_damage": { "damage_type": "stab", "amount": 40, "armor_penetration": 20 },
     "dispersion": 300,
     "durability": 6,
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "essence_dull_type": 40
-        }
-      }
-    ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_dull_type": 40 } } ],
     "clip_size": 50,
     "reload": 50,
-    "ammo_effects": [
-      "WIDE",
-      "LASER",
-      "BEANBAG",
-      "BLINDS_EYES"
-    ],
-    "flags": [
-      "NEVER_JAMS",
-      "PRIMITIVE_RANGED_WEAPON",
-      "NO_SALVAGE"
-    ],
+    "ammo_effects": [ "WIDE", "LASER", "BEANBAG", "BLINDS_EYES" ],
+    "flags": [ "NEVER_JAMS", "PRIMITIVE_RANGED_WEAPON", "NO_SALVAGE" ],
     "ammo_to_fire": 10,
-    "valid_mod_locations": [
-      [
-        "grip",
-        1
-      ],
-      [
-        "rail",
-        1
-      ],
-      [
-        "sights",
-        1
-      ]
-    ]
+    "valid_mod_locations": [ [ "grip", 1 ], [ "rail", 1 ], [ "sights", 1 ] ]
   },
   {
     "id": "ethereal_huge_crossbow",
     "type": "ITEM",
-    "subtypes": [
-      "GUN"
-    ],
+    "subtypes": [ "GUN" ],
     "category": "weapons",
-    "name": {
-      "str": "grand wraithslayer"
-    },
+    "name": { "str": "grand wraithslayer" },
     "description": "A massive medieval crossbow converted to an arcane weapon, removing its winch and bowstring and richly decorated with esoteric religious iconography.  It uses a large amount of dull essence to fire extremely powerful piercing bolts of energy.  While not as slow to load as its mundane counterpart, charging it with dull essence does take longer than normal.",
     "weight": "5670 g",
     "volume": "4 L",
@@ -478,82 +236,40 @@
     "price": "600 USD",
     "price_postapoc": "120 USD",
     "to_hit": -1,
-    "melee_damage": {
-      "bash": 22
-    },
-    "material": [
-      "iron",
-      "wood",
-      "gold"
-    ],
+    "melee_damage": { "bash": 22 },
+    "material": [ "iron", "wood", "gold" ],
     "symbol": "(",
     "looks_like": "huge_crossbow",
     "color": "green",
     "ammo": "essence_dull_type",
     "skill": "rifle",
     "range": 60,
-    "ranged_damage": {
-      "damage_type": "stab",
-      "amount": 160,
-      "armor_penetration": 75
-    },
+    "ranged_damage": { "damage_type": "stab", "amount": 160, "armor_penetration": 75 },
     "dispersion": 75,
     "durability": 6,
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "essence_dull_type": 200
-        }
-      }
-    ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_dull_type": 200 } } ],
     "clip_size": 90,
     "reload": 600,
-    "ammo_effects": [
-      "WIDE",
-      "LASER",
-      "LARGE_BEANBAG",
-      "BLINDS_EYES"
-    ],
-    "flags": [
-      "NEVER_JAMS",
-      "PRIMITIVE_RANGED_WEAPON",
-      "NO_SALVAGE"
-    ],
+    "ammo_effects": [ "WIDE", "LASER", "LARGE_BEANBAG", "BLINDS_EYES" ],
+    "flags": [ "NEVER_JAMS", "PRIMITIVE_RANGED_WEAPON", "NO_SALVAGE" ],
     "ammo_to_fire": 50,
-    "valid_mod_locations": [
-      [
-        "sling",
-        1
-      ]
-    ]
+    "valid_mod_locations": [ [ "sling", 1 ] ]
   },
   {
     "id": "hand_of_armok",
     "type": "ITEM",
-    "subtypes": [
-      "GUN",
-      "ARTIFACT"
-    ],
+    "subtypes": [ "GUN", "ARTIFACT" ],
     "category": "weapons",
-    "name": {
-      "str": "demon claw"
-    },
+    "name": { "str": "demon claw" },
     "description": "An ornate weapon resembling a clawed gauntlet, blades perpetually glowing red-hot.  Despite this, the weapon doesn't burn ones hand when grasped.  Firing it will smite your enemies and scour the land with wicked fire, to sate the god of blood.",
     "weight": "360 g",
     "volume": "750 ml",
     "longest_side": "30 cm",
     "price_postapoc": "120 USD",
     "to_hit": 3,
-    "melee_damage": {
-      "bash": 8,
-      "cut": 16
-    },
-    "material": [
-      "steel",
-      "essencemat"
-    ],
+    "melee_damage": { "bash": 8, "cut": 16 },
+    "light": 180,
+    "material": [ "steel", "essencemat" ],
     "symbol": "/",
     "looks_like": "bagh_nakha",
     "repairs_like": "bloodscourge",
@@ -562,100 +278,35 @@
     "skill": "magic",
     "range": 50,
     "//": "High as that amount is, this is equivalent to 10 essence a shot, and half the damage is over in the explosion.",
-    "ranged_damage": {
-      "damage_type": "heat",
-      "amount": 600,
-      "armor_penetration": 25
-    },
+    "ranged_damage": { "damage_type": "heat", "amount": 600, "armor_penetration": 25 },
     "dispersion": 200,
     "durability": 10,
     "loudness": 500,
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "essence_pure_type": 1
-        }
-      }
-    ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_pure_type": 1 } } ],
     "clip_size": 1,
     "reload": 200,
-    "use_action": {
-      "type": "cast_spell",
-      "spell_id": "arcana_item_sparks",
-      "no_fail": true,
-      "level": 0,
-      "need_wielding": true
-    },
-    "ammo_effects": [
-      "NAPALM_CLAW"
-    ],
-    "techniques": [
-      "WBLOCK_1"
-    ],
-    "qualities": [
-      [
-        "BUTCHER",
-        12
-      ]
-    ],
-    "flags": [
-      "LIGHT_45",
-      "NEVER_JAMS",
-      "UNBREAKABLE_MELEE",
-      "FIRE",
-      "FLAMING",
-      "PRIMITIVE_RANGED_WEAPON",
-      "TRADER_KEEP_EQUIPPED",
-      "NO_TURRET"
-    ],
+    "use_action": { "type": "cast_spell", "spell_id": "arcana_item_sparks", "no_fail": true, "level": 0, "need_wielding": true },
+    "ammo_effects": [ "NAPALM_CLAW" ],
+    "techniques": [ "WBLOCK_1" ],
+    "qualities": [ [ "BUTCHER", 12 ] ],
+    "flags": [ "NEVER_JAMS", "UNBREAKABLE_MELEE", "FIRE", "FLAMING", "PRIMITIVE_RANGED_WEAPON", "TRADER_KEEP_EQUIPPED", "NO_TURRET" ],
     "passive_effects": [
       {
         "has": "WIELD",
         "condition": "ALWAYS",
-        "hit_you_effect": [
-          {
-            "id": "arcana_react_drain_life",
-            "once_in": 3
-          }
-        ],
-        "intermittent_activation": {
-          "effects": [
-            {
-              "frequency": "25 minutes",
-              "spell_effects": [
-                {
-                  "id": "arcana_react_evil_mimic"
-                }
-              ]
-            }
-          ]
-        },
-        "ench_effects": [
-          {
-            "effect": "arcana_evil_mimic_active",
-            "intensity": 1
-          }
-        ]
+        "hit_you_effect": [ { "id": "arcana_react_drain_life", "once_in": 3 } ],
+        "intermittent_activation": { "effects": [ { "frequency": "25 minutes", "spell_effects": [ { "id": "arcana_react_evil_mimic" } ] } ] },
+        "ench_effects": [ { "effect": "arcana_evil_mimic_active", "intensity": 1 } ]
       }
     ]
   },
   {
     "id": "scourge_staff",
     "type": "ITEM",
-    "subtypes": [
-      "GUN",
-      "ARTIFACT"
-    ],
+    "subtypes": [ "GUN", "ARTIFACT" ],
     "category": "weapons",
-    "weapon_category": [
-      "QUARTERSTAVES"
-    ],
-    "name": {
-      "str": "bane staff",
-      "str_pl": "bane staves"
-    },
+    "weapon_category": [ "QUARTERSTAVES" ],
+    "name": { "str": "bane staff", "str_pl": "bane staves" },
     "description": "A wooden staff decorated with gold, capped with a dark blue gem.  The wood gives off a faintly acrid smell.  Firing it will produce pools of acid and toxic fumes.",
     "weight": "2800 g",
     "volume": "3 L",
@@ -663,14 +314,8 @@
     "//": "An out-of-context artifact, if it ever existed as a relic the Silver Enclave left behind it's become effectively unrecognizable, but more likely it was stuck in the creature that brought it here.",
     "price_postapoc": "100 USD",
     "to_hit": 3,
-    "melee_damage": {
-      "bash": 22
-    },
-    "material": [
-      "wood",
-      "gold",
-      "essencemat"
-    ],
+    "melee_damage": { "bash": 22 },
+    "material": [ "wood", "gold", "essencemat" ],
     "symbol": "/",
     "looks_like": "q_staff",
     "repairs_like": "staff_druidic",
@@ -678,36 +323,16 @@
     "ammo": "essence_blood_type",
     "skill": "magic",
     "range": 40,
-    "ranged_damage": {
-      "damage_type": "acid",
-      "amount": 80,
-      "armor_penetration": 10
-    },
+    "ranged_damage": { "damage_type": "acid", "amount": 80, "armor_penetration": 10 },
     "dispersion": 250,
     "durability": 10,
     "loudness": 75,
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "essence_blood_type": 8
-        }
-      }
-    ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_blood_type": 8 } } ],
     "clip_size": 8,
     "reload": 200,
     "ammo_to_fire": 2,
-    "ammo_effects": [
-      "ACIDBOMB",
-      "TOXICGAS",
-      "ARCANA_BANE_FUNG",
-      "ARCANA_BANE_TEAR"
-    ],
-    "techniques": [
-      "WBLOCK_1",
-      "RAPID"
-    ],
+    "ammo_effects": [ "ACIDBOMB", "TOXICGAS", "ARCANA_BANE_FUNG", "ARCANA_BANE_TEAR" ],
+    "techniques": [ "WBLOCK_1", "RAPID" ],
     "flags": [
       "UNBREAKABLE_MELEE",
       "NEVER_JAMS",
@@ -737,13 +362,9 @@
     "id": "electrothermal_arc_cannon",
     "looks_like": "plasma_rifle",
     "type": "ITEM",
-    "subtypes": [
-      "GUN"
-    ],
+    "subtypes": [ "GUN" ],
     "reload_noise_volume": 10,
-    "name": {
-      "str": "electrothermal arc cannon"
-    },
+    "name": { "str": "electrothermal arc cannon" },
     "description": "An advanced, though somewhat bulky, energy weapon exploiting exotic phenomenon.  Fires an anomalous bolt of energy that can jump from target to target, generating an electrothermal effect that leaves burning plasma and explosive bursts of electricity in its wake.  Highly indiscriminate, but equally destructive if used in a target-rich environment.",
     "weight": "5 kg",
     "volume": "3500 ml",
@@ -751,100 +372,46 @@
     "price": "16000 USD",
     "price_postapoc": "75 USD",
     "to_hit": -1,
-    "melee_damage": {
-      "bash": 12
-    },
-    "material": [
-      "steel",
-      "plastic"
-    ],
+    "melee_damage": { "bash": 12 },
+    "material": [ "steel", "plastic" ],
     "symbol": "(",
     "color": "yellow",
     "skill": "rifle",
     "range": 45,
     "//": "Base impact damage is only ~42%, but ammo effects include an explosion that bumps expected damage back up to the standard 50% of UPS draw.",
-    "ranged_damage": {
-      "damage_type": "heat",
-      "amount": 50
-    },
+    "ranged_damage": { "damage_type": "heat", "amount": 50 },
     "dispersion": 60,
     "durability": 7,
     "loudness": 35,
     "energy_drain": "120 kJ",
     "reload": 0,
     "valid_mod_locations": [
-      [
-        "accessories",
-        4
-      ],
-      [
-        "emitter",
-        1
-      ],
-      [
-        "grip",
-        1
-      ],
-      [
-        "rail",
-        1
-      ],
-      [
-        "sights",
-        1
-      ],
-      [
-        "sling",
-        1
-      ],
-      [
-        "stock",
-        1
-      ],
-      [
-        "underbarrel",
-        1
-      ]
+      [ "accessories", 4 ],
+      [ "emitter", 1 ],
+      [ "grip", 1 ],
+      [ "rail", 1 ],
+      [ "sights", 1 ],
+      [ "sling", 1 ],
+      [ "stock", 1 ],
+      [ "underbarrel", 1 ]
     ],
-    "ammo_effects": [
-      "PLASMA",
-      "AMMO_ELECTROTHERMAL_LIGHTNING",
-      "AMMO_ELECTROTHERMAL_FIRE",
-      "BOUNCE"
-    ],
-    "flags": [
-      "NEVER_JAMS",
-      "NO_UNLOAD",
-      "NON_FOULING",
-      "NEEDS_NO_LUBE",
-      "USE_UPS"
-    ]
+    "ammo_effects": [ "PLASMA", "AMMO_ELECTROTHERMAL_LIGHTNING", "AMMO_ELECTROTHERMAL_FIRE", "BOUNCE" ],
+    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE", "USE_UPS" ]
   },
   {
     "id": "rift_focus_cannon",
     "looks_like": "laser_rifle",
     "type": "ITEM",
-    "subtypes": [
-      "GUN"
-    ],
+    "subtypes": [ "GUN" ],
     "reload_noise_volume": 10,
     "symbol": "(",
     "color": "light_blue",
-    "name": {
-      "str": "rift focus cannon"
-    },
+    "name": { "str": "rift focus cannon" },
     "description": "A bulky, heavy-duty experimental rifle with peculiar golden inlays along the length of its body.  Exploits otherworldly energy to tear a rift in reality, focusing it into a highly-destructive beam that risks carving wounds in The Veil with each shot.  While its impact creates an EMP effect, the beam itself is utterly useless against robotic targets, and some anomalous monsters may also be immune to it.  Consuming crystallized essence to fire makes its overall energy usage considerable, but its overwhelming power makes it more efficient than most energy weapons.",
     "price": "1800 USD",
     "price_postapoc": "80 USD",
-    "material": [
-      "steel",
-      "plastic"
-    ],
-    "flags": [
-      "NEVER_JAMS",
-      "NON_FOULING",
-      "NEEDS_NO_LUBE"
-    ],
+    "material": [ "steel", "plastic" ],
+    "flags": [ "NEVER_JAMS", "NON_FOULING", "NEEDS_NO_LUBE" ],
     "ammo_effects": [
       "LASER",
       "PLASMA_BUBBLE",
@@ -855,321 +422,160 @@
       "AMMO_RIFT_FOCUS_SLEEPINESS"
     ],
     "skill": "rifle",
-    "ammo": [
-      "essence_pure_type"
-    ],
+    "ammo": [ "essence_pure_type" ],
     "weight": "6 kg",
     "volume": "4 L",
     "longest_side": "120 cm",
-    "melee_damage": {
-      "bash": 14
-    },
+    "melee_damage": { "bash": 14 },
     "to_hit": -1,
     "range": 60,
-    "ranged_damage": {
-      "damage_type": "cold",
-      "amount": 1200
-    },
+    "ranged_damage": { "damage_type": "cold", "amount": 1200 },
     "loudness": 50,
     "dispersion": 20,
     "durability": 7,
     "clip_size": 1,
     "reload": 250,
     "valid_mod_locations": [
-      [
-        "accessories",
-        4
-      ],
-      [
-        "emitter",
-        1
-      ],
-      [
-        "grip",
-        1
-      ],
-      [
-        "mechanism",
-        4
-      ],
-      [
-        "rail",
-        1
-      ],
-      [
-        "sights",
-        1
-      ],
-      [
-        "sling",
-        1
-      ],
-      [
-        "stock",
-        1
-      ],
-      [
-        "underbarrel",
-        1
-      ]
+      [ "accessories", 4 ],
+      [ "emitter", 1 ],
+      [ "grip", 1 ],
+      [ "mechanism", 4 ],
+      [ "rail", 1 ],
+      [ "sights", 1 ],
+      [ "sling", 1 ],
+      [ "stock", 1 ],
+      [ "underbarrel", 1 ]
     ],
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "ammo_restriction": {
-          "essence_pure_type": 1
-        }
-      }
-    ]
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "essence_pure_type": 1 } } ]
   },
   {
     "id": "monster_fire_fake",
     "type": "ITEM",
-    "subtypes": [
-      "GUN"
-    ],
+    "subtypes": [ "GUN" ],
     "copy-from": "fake_item",
-    "name": {
-      "str": "monster fire weapon"
-    },
+    "name": { "str": "monster fire weapon" },
     "description": "Used to give fire-breathing bosses in Arcana a specific degree of inaccuracy.  If you encounter one of these in the wild, it's a bug.",
-    "ammo_effects": [
-      "NEVER_MISFIRES",
-      "STREAM",
-      "IGNITE"
-    ],
-    "flags": [
-      "NEVER_JAMS"
-    ],
+    "ammo_effects": [ "NEVER_MISFIRES", "STREAM", "IGNITE" ],
+    "flags": [ "NEVER_JAMS" ],
     "skill": "pistol",
     "durability": 10,
     "range": 7,
     "dispersion": 7500,
     "sight_dispersion": 1000,
     "//": "Roughly half the damage of closest weapon equivalent, rounded up.",
-    "ranged_damage": {
-      "damage_type": "heat",
-      "amount": 13,
-      "armor_penetration": 5
-    }
+    "ranged_damage": { "damage_type": "heat", "amount": 13, "armor_penetration": 5 }
   },
   {
     "id": "monster_lightning_fake",
     "type": "ITEM",
-    "subtypes": [
-      "GUN"
-    ],
+    "subtypes": [ "GUN" ],
     "copy-from": "fake_item",
-    "name": {
-      "str": "monster lightning weapon"
-    },
+    "name": { "str": "monster lightning weapon" },
     "description": "Used to give the Host of the Archon a specific degree of inaccuracy.  If you encounter one of these in the wild, it's a bug.",
-    "ammo_effects": [
-      "NEVER_MISFIRES",
-      "LIGHTNING"
-    ],
-    "flags": [
-      "NEVER_JAMS"
-    ],
+    "ammo_effects": [ "NEVER_MISFIRES", "LIGHTNING" ],
+    "flags": [ "NEVER_JAMS" ],
     "skill": "pistol",
     "durability": 10,
     "range": 25,
     "dispersion": 5000,
     "sight_dispersion": 1000,
     "loudness": 50,
-    "ranged_damage": {
-      "damage_type": "electric",
-      "amount": 38,
-      "armor_penetration": 10
-    }
+    "ranged_damage": { "damage_type": "electric", "amount": 38, "armor_penetration": 10 }
   },
   {
     "id": "monster_hammer_fake",
     "type": "ITEM",
-    "subtypes": [
-      "GUN"
-    ],
+    "subtypes": [ "GUN" ],
     "copy-from": "fake_item",
-    "name": {
-      "str": "monster flashbang"
-    },
+    "name": { "str": "monster flashbang" },
     "description": "Used to give the maddened hunters a telegraphed flashbang effect.  If you encounter one of these in the wild, it's a bug.",
-    "ammo_effects": [
-      "NEVER_MISFIRES",
-      "FLASHBANG"
-    ],
-    "flags": [
-      "NEVER_JAMS"
-    ],
+    "ammo_effects": [ "NEVER_MISFIRES", "FLASHBANG" ],
+    "flags": [ "NEVER_JAMS" ],
     "skill": "pistol",
     "durability": 10,
     "range": 0,
     "dispersion": 5000,
     "sight_dispersion": 1000,
-    "ranged_damage": {
-      "damage_type": "heat",
-      "amount": 0
-    }
+    "ranged_damage": { "damage_type": "heat", "amount": 0 }
   },
   {
     "id": "monster_laser_fake",
     "type": "ITEM",
-    "subtypes": [
-      "GUN"
-    ],
+    "subtypes": [ "GUN" ],
     "copy-from": "fake_item",
-    "name": {
-      "str": "monster laser weapon"
-    },
+    "name": { "str": "monster laser weapon" },
     "description": "Used to give the Seraphic Shade a specific degree of inaccuracy.  If you encounter one of these in the wild, it's a bug.",
-    "ammo_effects": [
-      "NEVER_MISFIRES",
-      "LASER",
-      "BLINDS_EYES"
-    ],
-    "flags": [
-      "NEVER_JAMS"
-    ],
+    "ammo_effects": [ "NEVER_MISFIRES", "LASER", "BLINDS_EYES" ],
+    "flags": [ "NEVER_JAMS" ],
     "skill": "pistol",
     "durability": 10,
     "range": 20,
     "dispersion": 5000,
     "sight_dispersion": 1000,
-    "ranged_damage": {
-      "damage_type": "cold",
-      "amount": 20
-    }
+    "ranged_damage": { "damage_type": "cold", "amount": 20 }
   },
   {
     "id": "mut_dragonfire",
     "type": "ITEM",
-    "subtypes": [
-      "GUN"
-    ],
-    "name": {
-      "str": "dragonfire",
-      "str_pl": "dragonfire"
-    },
+    "subtypes": [ "GUN" ],
+    "name": { "str": "dragonfire", "str_pl": "dragonfire" },
     "description": "Cited by dragonfire mutation, this is a pseudo item.",
-    "material": [
-      "essencemat"
-    ],
+    "material": [ "essencemat" ],
     "symbol": "(",
     "color": "red",
     "skill": "magic",
     "range": 10,
-    "ranged_damage": {
-      "damage_type": "heat",
-      "amount": 120,
-      "armor_penetration": 25
-    },
+    "ranged_damage": { "damage_type": "heat", "amount": 120, "armor_penetration": 25 },
     "dispersion": 300,
     "durability": 10,
     "loudness": 5,
     "reload": 500,
-    "ammo_effects": [
-      "WIDE",
-      "AMMO_DRAGONFIRE_ARCANA",
-      "IGNITE"
-    ],
-    "flags": [
-      "NEVER_JAMS",
-      "TRADER_AVOID",
-      "ZERO_WEIGHT"
-    ]
+    "ammo_effects": [ "WIDE", "AMMO_DRAGONFIRE_ARCANA", "IGNITE" ],
+    "flags": [ "NEVER_JAMS", "TRADER_AVOID", "ZERO_WEIGHT" ]
   },
   {
     "id": "bio_electrothermal_arc_projector_gun",
     "type": "ITEM",
-    "subtypes": [
-      "GUN"
-    ],
-    "name": {
-      "str": "electrothermal arc projector"
-    },
+    "subtypes": [ "GUN" ],
+    "name": { "str": "electrothermal arc projector" },
     "description": "this a pseudo item",
     "volume": "3 L",
     "weight": "3 kg",
-    "material": [
-      "steel",
-      "plastic"
-    ],
+    "material": [ "steel", "plastic" ],
     "symbol": "(",
     "looks_like": "v29",
     "color": "magenta",
     "skill": "pistol",
     "range": 30,
-    "ranged_damage": {
-      "damage_type": "heat",
-      "amount": 30
-    },
+    "ranged_damage": { "damage_type": "heat", "amount": 30 },
     "dispersion": 90,
     "durability": 10,
     "loudness": 9,
     "energy_drain": "80 kJ",
-    "ammo_effects": [
-      "AMMO_ELECTROTHERMAL_LIGHTNING",
-      "AMMO_ELECTROTHERMAL_FIRE_SMALL",
-      "BOUNCE"
-    ],
-    "flags": [
-      "NEVER_JAMS",
-      "TRADER_AVOID",
-      "USES_BIONIC_POWER"
-    ]
+    "ammo_effects": [ "AMMO_ELECTROTHERMAL_LIGHTNING", "AMMO_ELECTROTHERMAL_FIRE_SMALL", "BOUNCE" ],
+    "flags": [ "NEVER_JAMS", "TRADER_AVOID", "USES_BIONIC_POWER" ]
   },
   {
     "id": "bio_rift_focus_projector_gun",
     "type": "ITEM",
-    "subtypes": [
-      "GUN"
-    ],
-    "name": {
-      "str": "rift focus projector"
-    },
+    "subtypes": [ "GUN" ],
+    "name": { "str": "rift focus projector" },
     "description": "this a pseudo item",
     "volume": "3 L",
     "weight": "3 kg",
-    "material": [
-      "steel",
-      "plastic"
-    ],
+    "material": [ "steel", "plastic" ],
     "symbol": "(",
     "looks_like": "v29",
     "color": "magenta",
     "skill": "pistol",
     "range": 40,
-    "ranged_damage": {
-      "damage_type": "cold",
-      "amount": 40
-    },
+    "ranged_damage": { "damage_type": "cold", "amount": 40 },
     "dispersion": 30,
     "durability": 10,
     "loudness": 9,
     "energy_drain": "60 kJ",
-    "modes": [
-      [
-        "DEFAULT",
-        "semi-auto",
-        1
-      ],
-      [
-        "BURST",
-        "burst",
-        3
-      ]
-    ],
-    "ammo_effects": [
-      "LASER",
-      "BLINDS_EYES",
-      "BEANBAG",
-      "AMMO_RIFT_FOCUS_SHADOWS",
-      "AMMO_RIFT_FOCUS_TINDALOS"
-    ],
-    "flags": [
-      "NEVER_JAMS",
-      "TRADER_AVOID",
-      "USES_BIONIC_POWER"
-    ]
+    "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "BURST", "burst", 3 ] ],
+    "ammo_effects": [ "LASER", "BLINDS_EYES", "BEANBAG", "AMMO_RIFT_FOCUS_SHADOWS", "AMMO_RIFT_FOCUS_TINDALOS" ],
+    "flags": [ "NEVER_JAMS", "TRADER_AVOID", "USES_BIONIC_POWER" ]
   }
 ]

--- a/Arcana/items/tool_armor.json
+++ b/Arcana/items/tool_armor.json
@@ -4,237 +4,90 @@
     "copy-from": "triffid_garland",
     "sub": "triffid_garland",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL",
-      "ARMOR",
-      "ARTIFACT"
-    ],
-    "name": {
-      "str": "verdant triffid garland"
-    },
+    "subtypes": [ "TOOL", "ARMOR", "ARTIFACT" ],
+    "name": { "str": "verdant triffid garland" },
     "description": "A wreath of brightly-colored flowers from another world, worn around the neck.  Elemental magic has been woven into its structure, converting it into a primitive magic item.  Using it will grant a burst of renewed stamina, recovering pain and speeding up the body's natural healing.  It will take a long time to recharge after each use, and activating it also fatigues the user.  It can hold up to 5 uses, each use takes 25 hours to charge.",
     "price_postapoc": "12 USD",
     "charges_per_use": 25,
     "tool_ammo": "primitive_magic_item_ammo_type",
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "primitive_magic_item_ammo_type": 125
-        }
-      }
-    ],
-    "flags": [
-      "FANCY",
-      "NO_RELOAD",
-      "NO_UNLOAD",
-      "TARDIS"
-    ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "primitive_magic_item_ammo_type": 125 } } ],
+    "flags": [ "FANCY", "NO_RELOAD", "NO_UNLOAD", "TARDIS" ],
     "//": "Water talisman and earth talisman.  Each use has power equivalent to 250 mana.",
-    "use_action": {
-      "type": "cast_spell",
-      "spell_id": "arcana_item_triffid_garland_empowered",
-      "no_fail": true,
-      "level": 0
-    },
-    "charge_info": {
-      "recharge_type": "periodic",
-      "time": "1 h",
-      "regenerate_ammo": true
-    }
+    "use_action": { "type": "cast_spell", "spell_id": "arcana_item_triffid_garland_empowered", "no_fail": true, "level": 0 },
+    "charge_info": { "recharge_type": "periodic", "time": "1 h", "regenerate_ammo": true }
   },
   {
     "id": "amulet_exotic_empowered",
     "copy-from": "amulet_exotic",
     "sub": "amulet_exotic",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL",
-      "ARMOR",
-      "ARTIFACT"
-    ],
-    "name": {
-      "str": "shrouded exotic amulet"
-    },
+    "subtypes": [ "TOOL", "ARMOR", "ARTIFACT" ],
+    "name": { "str": "shrouded exotic amulet" },
     "description": "A makeshift necklace with a single gem, a charm worked from some manner of unnatural material.  Elemental magic has been woven into its structure, converting it into a primitive magic item.  Activating it will shroud your life force, rendering you invisible (but not inaudible) to the undead, in exchange for making mundane wildlife more aggressive towards you.  It will take a long time to recharge after each use, and activating it also fatigues the user.  It can hold up to 5 uses, each use takes 28 hours to charge.",
     "price_postapoc": "15 USD",
     "charges_per_use": 35,
     "tool_ammo": "primitive_magic_item_ammo_type",
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "primitive_magic_item_ammo_type": 175
-        }
-      }
-    ],
-    "flags": [
-      "FANCY",
-      "NO_RELOAD",
-      "NO_UNLOAD",
-      "TARDIS"
-    ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "primitive_magic_item_ammo_type": 175 } } ],
+    "flags": [ "FANCY", "NO_RELOAD", "NO_UNLOAD", "TARDIS" ],
     "//": "Flame talisman and air talisman.  Each use has power equivalent to 350 mana.",
-    "use_action": {
-      "type": "cast_spell",
-      "spell_id": "arcana_item_amulet_exotic_empowered",
-      "no_fail": true,
-      "level": 0
-    },
-    "charge_info": {
-      "recharge_type": "periodic",
-      "time": "1 h",
-      "regenerate_ammo": true
-    }
+    "use_action": { "type": "cast_spell", "spell_id": "arcana_item_amulet_exotic_empowered", "no_fail": true, "level": 0 },
+    "charge_info": { "recharge_type": "periodic", "time": "1 h", "regenerate_ammo": true }
   },
   {
     "id": "brooch_iridescent_empowered",
     "copy-from": "brooch_iridescent",
     "sub": "brooch_iridescent",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL",
-      "ARMOR",
-      "ARTIFACT"
-    ],
-    "name": {
-      "str": "bolstered iridescent brooch"
-    },
+    "subtypes": [ "TOOL", "ARMOR", "ARTIFACT" ],
+    "name": { "str": "bolstered iridescent brooch" },
     "description": "A hand-crafted disc brooch made from a strange, unearthly material vaguely resembling mother-of-pearl  Elemental magic has been woven into its structure, converting it into a primitive magic item.  Using it will double any armor or damage resistance you have.  It will take a long time to recharge after each use, and activating it also fatigues the user.  It can hold up to 5 uses, each use takes 45 hours to charge.",
     "price_postapoc": "20 USD",
     "charges_per_use": 45,
     "tool_ammo": "primitive_magic_item_ammo_type",
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "primitive_magic_item_ammo_type": 225
-        }
-      }
-    ],
-    "flags": [
-      "FANCY",
-      "NO_RELOAD",
-      "NO_UNLOAD",
-      "TARDIS"
-    ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "primitive_magic_item_ammo_type": 225 } } ],
+    "flags": [ "FANCY", "NO_RELOAD", "NO_UNLOAD", "TARDIS" ],
     "//": "Earth talisman and air talisman.  Each use has power equivalent to 450 mana.",
-    "use_action": {
-      "type": "cast_spell",
-      "spell_id": "arcana_item_brooch_iridescent_empowered",
-      "no_fail": true,
-      "level": 0
-    },
-    "charge_info": {
-      "recharge_type": "periodic",
-      "time": "1 h",
-      "regenerate_ammo": true
-    }
+    "use_action": { "type": "cast_spell", "spell_id": "arcana_item_brooch_iridescent_empowered", "no_fail": true, "level": 0 },
+    "charge_info": { "recharge_type": "periodic", "time": "1 h", "regenerate_ammo": true }
   },
   {
     "id": "gilded_aegis",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL",
-      "ARMOR"
-    ],
+    "subtypes": [ "TOOL", "ARMOR" ],
     "copy-from": "cloak_leather",
     "category": "armor",
-    "name": {
-      "str": "gilded aegis",
-      "str_pl": "gilded aegises"
-    },
+    "name": { "str": "gilded aegis", "str_pl": "gilded aegises" },
     "description": "A simple leather cloak, richly decorated with scales of gilded iron.  It resembles the hide of a golden dragon or serpent.  Using it will heal minor injuries, in exchange for inflicting pain.",
-    "material": [
-      "leather",
-      "iron",
-      "gold"
-    ],
+    "material": [ "leather", "iron", "gold" ],
     "//": "A reusable healing item that's also armored?  Yeah, that's staying valuable for a while.",
     "price": "700 USD",
     "price_postapoc": "80 USD",
     "color": "yellow",
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "essence_dull_type": 60
-        }
-      }
-    ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_dull_type": 60 } } ],
     "charges_per_use": 60,
     "tool_ammo": "essence_dull_type",
-    "use_action": {
-      "type": "cast_spell",
-      "spell_id": "arcana_item_gilded_aegis_healing",
-      "no_fail": true,
-      "level": 0,
-      "need_worn": true
-    },
-    "relative": {
-      "weight": "3020 g"
-    },
-    "extend": {
-      "flags": [
-        "NO_SALVAGE",
-        "FANCY",
-        "TRADER_KEEP_EQUIPPED"
-      ]
-    },
+    "use_action": { "type": "cast_spell", "spell_id": "arcana_item_gilded_aegis_healing", "no_fail": true, "level": 0, "need_worn": true },
+    "relative": { "weight": "3020 g" },
+    "extend": { "flags": [ "NO_SALVAGE", "FANCY", "TRADER_KEEP_EQUIPPED" ] },
     "material_thickness": 5,
-    "armor": [
-      {
-        "encumbrance": 12,
-        "coverage": 100,
-        "covers": [
-          "torso",
-          "arm_l",
-          "arm_r",
-          "leg_l",
-          "leg_r"
-        ]
-      }
-    ]
+    "armor": [ { "encumbrance": 12, "coverage": 100, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ] } ]
   },
   {
     "id": "somen_clairvoyance",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL",
-      "ARMOR",
-      "ARTIFACT"
-    ],
+    "subtypes": [ "TOOL", "ARMOR", "ARTIFACT" ],
     "category": "armor",
-    "name": {
-      "str": "mask of insight",
-      "str_pl": "masks of insight"
-    },
+    "name": { "str": "mask of insight", "str_pl": "masks of insight" },
     "description": "A mask faced with iron and decorated with other metal, depicting the face of some unknown divine figure.  Fueling it with consecrated essence will grant the wearer clairvoyance within a limited range and protection from bright flashes, but blind you to anything beyond its effect.",
     "weight": "710 g",
     "volume": "1 L",
     "price": "210 USD",
     "price_postapoc": "40 USD",
-    "material": [
-      "iron",
-      "copper",
-      "leather"
-    ],
+    "material": [ "iron", "copper", "leather" ],
     "symbol": "[",
     "looks_like": "mask_bal",
     "color": "light_red",
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "essence_dull_type": 24
-        }
-      }
-    ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_dull_type": 24 } } ],
     "charges_per_use": 1,
     "tool_ammo": "essence_dull_type",
     "warmth": 10,
@@ -248,66 +101,31 @@
       "type": "transform",
       "ammo_scale": 0
     },
-    "flags": [
-      "NO_SALVAGE",
-      "TRADER_KEEP_EQUIPPED"
-    ],
+    "flags": [ "NO_SALVAGE", "TRADER_KEEP_EQUIPPED" ],
     "material_thickness": 4,
     "environmental_protection": 1,
-    "armor": [
-      {
-        "encumbrance": 12,
-        "coverage": 100,
-        "covers": [
-          "eyes",
-          "mouth"
-        ]
-      }
-    ],
+    "armor": [ { "encumbrance": 12, "coverage": 100, "covers": [ "eyes", "mouth" ] } ],
     "passive_effects": [
       {
         "has": "WORN",
         "condition": "ACTIVE",
-        "mutations": [
-          "ARCANA_MASK_INSIGHT_EFFECT"
-        ],
-        "values": [
-          {
-            "value": "BONUS_DODGE",
-            "add": 2
-          }
-        ],
-        "ench_effects": [
-          {
-            "effect": "mask_blind_immunity",
-            "intensity": 1
-          }
-        ]
+        "mutations": [ "ARCANA_MASK_INSIGHT_EFFECT" ],
+        "values": [ { "value": "BONUS_DODGE", "add": 2 } ],
+        "ench_effects": [ { "effect": "mask_blind_immunity", "intensity": 1 } ]
       }
     ]
   },
   {
     "id": "somen_clairvoyance_on",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL",
-      "ARMOR"
-    ],
+    "subtypes": [ "TOOL", "ARMOR" ],
     "copy-from": "somen_clairvoyance",
     "repairs_like": "somen_clairvoyance",
-    "name": {
-      "str": "mask of insight (on)",
-      "str_pl": "masks of insight (on)"
-    },
+    "name": { "str": "mask of insight (on)", "str_pl": "masks of insight (on)" },
     "description": "A mask faced with iron and decorated with other metal, depicting the face of some unknown divine figure.  The face depicted on the mask seems more menacing than it did previously.",
     "turns_per_charge": 100,
     "revert_to": "somen_clairvoyance",
-    "qualities": [
-      [
-        "GLARE",
-        1
-      ]
-    ],
+    "qualities": [ [ "GLARE", 1 ] ],
     "use_action": {
       "target": "somen_clairvoyance",
       "msg": "The mask's features return to its original impassive expression.",
@@ -315,50 +133,25 @@
       "type": "transform",
       "ammo_scale": 0
     },
-    "extend": {
-      "flags": [
-        "SUN_GLASSES",
-        "BLIND",
-        "IR_EFFECT",
-        "PARTIAL_DEAF"
-      ]
-    }
+    "extend": { "flags": [ "SUN_GLASSES", "BLIND", "IR_EFFECT", "PARTIAL_DEAF" ] }
   },
   {
     "id": "somen_clairvoyance_xl",
     "repairs_like": "somen_clairvoyance",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL",
-      "ARMOR",
-      "ARTIFACT"
-    ],
+    "subtypes": [ "TOOL", "ARMOR", "ARTIFACT" ],
     "category": "armor",
-    "name": {
-      "str": "hunter's visor"
-    },
+    "name": { "str": "hunter's visor" },
     "description": "A half-mask covering the top half of the face, made of iron decorated with other metal.  Loose-fitting and designed with mutant anatomy in mind, and to be worn over other items.  Fueling it with consecrated essence will grant the wearer clairvoyance within a limited range and protection from bright flashes, but blind you to anything beyond its effect.",
     "weight": "500 g",
     "volume": "750 ml",
     "price": "210 USD",
     "price_postapoc": "40 USD",
-    "material": [
-      "iron",
-      "copper",
-      "leather"
-    ],
+    "material": [ "iron", "copper", "leather" ],
     "symbol": "[",
     "looks_like": "mask_bal",
     "color": "light_red",
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "essence_dull_type": 24
-        }
-      }
-    ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_dull_type": 24 } } ],
     "charges_per_use": 1,
     "tool_ammo": "essence_dull_type",
     "use_action": {
@@ -371,66 +164,30 @@
       "type": "transform",
       "ammo_scale": 0
     },
-    "flags": [
-      "NO_SALVAGE",
-      "OVERSIZE",
-      "OUTER",
-      "POWERARMOR_COMPATIBLE"
-    ],
+    "flags": [ "NO_SALVAGE", "OVERSIZE", "OUTER", "POWERARMOR_COMPATIBLE" ],
     "material_thickness": 4,
     "environmental_protection": 1,
-    "armor": [
-      {
-        "encumbrance": 12,
-        "coverage": 100,
-        "covers": [
-          "eyes"
-        ]
-      }
-    ],
+    "armor": [ { "encumbrance": 12, "coverage": 100, "covers": [ "eyes" ] } ],
     "passive_effects": [
       {
         "has": "WORN",
         "condition": "ACTIVE",
-        "mutations": [
-          "ARCANA_MASK_INSIGHT_EFFECT"
-        ],
-        "values": [
-          {
-            "value": "BONUS_DODGE",
-            "add": 2
-          }
-        ],
-        "ench_effects": [
-          {
-            "effect": "mask_blind_immunity",
-            "intensity": 1
-          }
-        ]
+        "mutations": [ "ARCANA_MASK_INSIGHT_EFFECT" ],
+        "values": [ { "value": "BONUS_DODGE", "add": 2 } ],
+        "ench_effects": [ { "effect": "mask_blind_immunity", "intensity": 1 } ]
       }
     ]
   },
   {
     "id": "somen_clairvoyance_xl_on",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL",
-      "ARMOR"
-    ],
+    "subtypes": [ "TOOL", "ARMOR" ],
     "copy-from": "somen_clairvoyance_xl",
-    "name": {
-      "str": "hunter's visor (on)",
-      "str_pl": "hunter's visors (on)"
-    },
+    "name": { "str": "hunter's visor (on)", "str_pl": "hunter's visors (on)" },
     "description": "A half-mask covering the top half of the face, made of iron decorated with other metal.  It vaguely gives the appearance of a hateful glare.",
     "turns_per_charge": 100,
     "revert_to": "somen_clairvoyance_xl",
-    "qualities": [
-      [
-        "GLARE",
-        1
-      ]
-    ],
+    "qualities": [ [ "GLARE", 1 ] ],
     "use_action": {
       "target": "somen_clairvoyance_xl",
       "msg": "The visor shifts back to its normal appearance.",
@@ -438,39 +195,21 @@
       "type": "transform",
       "ammo_scale": 0
     },
-    "extend": {
-      "flags": [
-        "SUN_GLASSES",
-        "BLIND",
-        "IR_EFFECT",
-        "PARTIAL_DEAF"
-      ]
-    }
+    "extend": { "flags": [ "SUN_GLASSES", "BLIND", "IR_EFFECT", "PARTIAL_DEAF" ] }
   },
   {
     "id": "armor_wyrm",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL",
-      "ARMOR"
-    ],
-    "name": {
-      "str": "wyrmskin armor",
-      "str_pl": "sets of wyrmskin armor"
-    },
+    "subtypes": [ "TOOL", "ARMOR" ],
+    "name": { "str": "wyrmskin armor", "str_pl": "sets of wyrmskin armor" },
     "description": "A set of well-decorated leather armor, with serpentine patterns sewn into it and various adjustable straps added.  It can be used to conjure a long-lasting spray of acid.",
     "weight": "4400 g",
     "volume": "9 L",
-    "material": [
-      "wyrmskin",
-      "leather"
-    ],
+    "material": [ "wyrmskin", "leather" ],
     "price": "450 USD",
     "price_postapoc": "30 USD",
     "to_hit": -5,
-    "melee_damage": {
-      "bash": 2
-    },
+    "melee_damage": { "bash": 2 },
     "symbol": "[",
     "looks_like": "leather_cuirass",
     "color": "green",
@@ -478,126 +217,50 @@
     "environmental_protection": 10,
     "armor": [
       {
-        "covers": [
-          "torso"
-        ],
+        "covers": [ "torso" ],
         "coverage": 95,
         "encumbrance": 8,
         "material": [
-          {
-            "type": "leather",
-            "covered_by_mat": 100,
-            "thickness": 2.5
-          },
-          {
-            "type": "wyrmskin",
-            "covered_by_mat": 100,
-            "thickness": 2.5
-          }
+          { "type": "leather", "covered_by_mat": 100, "thickness": 2.5 },
+          { "type": "wyrmskin", "covered_by_mat": 100, "thickness": 2.5 }
         ]
       },
+      { "covers": [ "arm_l", "arm_r" ], "coverage": 90, "encumbrance": 7 },
+      { "covers": [ "leg_l", "leg_r" ], "coverage": 85, "encumbrance": 7 },
       {
-        "covers": [
-          "arm_l",
-          "arm_r"
-        ],
-        "coverage": 90,
-        "encumbrance": 7
-      },
-      {
-        "covers": [
-          "leg_l",
-          "leg_r"
-        ],
-        "coverage": 85,
-        "encumbrance": 7
-      },
-      {
-        "covers": [
-          "foot_l",
-          "foot_r"
-        ],
+        "covers": [ "foot_l", "foot_r" ],
         "coverage": 100,
         "encumbrance": 9,
         "material": [
-          {
-            "type": "leather",
-            "covered_by_mat": 100,
-            "thickness": 2.5
-          },
-          {
-            "type": "wyrmskin",
-            "covered_by_mat": 100,
-            "thickness": 2.5
-          }
+          { "type": "leather", "covered_by_mat": 100, "thickness": 2.5 },
+          { "type": "wyrmskin", "covered_by_mat": 100, "thickness": 2.5 }
         ]
       }
     ],
     "warmth": 20,
     "charges_per_use": 2,
     "tool_ammo": "essence_blood_type",
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "essence_blood_type": 16
-        }
-      }
-    ],
-    "use_action": [
-      {
-        "type": "cast_spell",
-        "spell_id": "arcana_item_wyrmskin_acid",
-        "no_fail": true,
-        "level": 0,
-        "need_worn": true
-      }
-    ],
-    "flags": [
-      "OVERSIZE",
-      "NO_SALVAGE",
-      "ALLOWS_NATURAL_ATTACKS",
-      "FANCY",
-      "TRADER_KEEP_EQUIPPED",
-      "POCKETS",
-      "STURDY"
-    ]
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_blood_type": 16 } } ],
+    "use_action": [ { "type": "cast_spell", "spell_id": "arcana_item_wyrmskin_acid", "no_fail": true, "level": 0, "need_worn": true } ],
+    "flags": [ "OVERSIZE", "NO_SALVAGE", "ALLOWS_NATURAL_ATTACKS", "FANCY", "TRADER_KEEP_EQUIPPED", "POCKETS", "STURDY" ]
   },
   {
     "id": "revenant_crown",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL",
-      "ARMOR",
-      "ARTIFACT"
-    ],
+    "subtypes": [ "TOOL", "ARMOR", "ARTIFACT" ],
     "category": "clothing",
-    "name": {
-      "str": "revenant crown"
-    },
+    "name": { "str": "revenant crown" },
     "description": "A wicked-looking crown made of precious metal, decorated with scenes of skeletons in a \"danse macabre\" motif.  A single brilliant gem adorns it, in the center of the scene depicted.  Using it shall yield immunity to food poisoning and parasites, in exchange for increased hunger.  It will not cure existing ailments, only prevent them.",
     "weight": "650 g",
     "volume": "3500 ml",
     "price": "150 USD",
     "price_postapoc": "40 USD",
     "to_hit": -1,
-    "material": [
-      "silver",
-      "diamond"
-    ],
+    "material": [ "silver", "diamond" ],
     "symbol": "[",
     "looks_like": "crown_silver",
     "color": "yellow",
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "essence_blood_type": 6
-        }
-      }
-    ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_blood_type": 6 } } ],
     "charges_per_use": 2,
     "tool_ammo": "essence_blood_type",
     "use_action": [
@@ -613,37 +276,15 @@
         "ammo_scale": 0
       }
     ],
-    "flags": [
-      "BELTED",
-      "OVERSIZE",
-      "NO_SALVAGE",
-      "ALLOWS_NATURAL_ATTACKS",
-      "TRADER_KEEP_EQUIPPED",
-      "POWERARMOR_COMPATIBLE"
-    ],
+    "flags": [ "BELTED", "OVERSIZE", "NO_SALVAGE", "ALLOWS_NATURAL_ATTACKS", "TRADER_KEEP_EQUIPPED", "POWERARMOR_COMPATIBLE" ],
     "material_thickness": 1,
-    "armor": [
-      {
-        "coverage": 20,
-        "covers": [
-          "head"
-        ]
-      }
-    ],
+    "armor": [ { "coverage": 20, "covers": [ "head" ] } ],
     "passive_effects": [
       {
         "has": "WORN",
         "condition": "ACTIVE",
-        "mutations": [
-          "EATDEAD",
-          "ARCANA_TOXINIMMUNE"
-        ],
-        "ench_effects": [
-          {
-            "effect": "revenant_hunger",
-            "intensity": 1
-          }
-        ]
+        "mutations": [ "EATDEAD", "ARCANA_TOXINIMMUNE" ],
+        "ench_effects": [ { "effect": "revenant_hunger", "intensity": 1 } ]
       }
     ]
   },
@@ -652,14 +293,8 @@
     "copy-from": "revenant_crown",
     "repairs_like": "revenant_crown",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL",
-      "ARMOR"
-    ],
-    "name": {
-      "str": "revenant crown (on)",
-      "str_pl": "revenant crown (on)"
-    },
+    "subtypes": [ "TOOL", "ARMOR" ],
+    "name": { "str": "revenant crown (on)", "str_pl": "revenant crown (on)" },
     "description": "A wicked-looking crown made of precious metal, decorated with scenes of skeletons in a \"danse macabre\" motif.  A single brilliant gem adorns it, seemingly aglow with a blood-red tinge.  While active it protects against food poisoning and parasites, in exchange for increased hunger.  It will not cure existing ailments, only prevent them.  Use it to turn it back off.",
     "turns_per_charge": 900,
     "revert_to": "revenant_crown",
@@ -676,36 +311,19 @@
   {
     "id": "robe_shadow",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL",
-      "ARMOR",
-      "ARTIFACT"
-    ],
+    "subtypes": [ "TOOL", "ARMOR", "ARTIFACT" ],
     "copy-from": "robe",
     "category": "armor",
-    "name": {
-      "str": "mantle of shadows",
-      "str_pl": "mantles of shadows"
-    },
+    "name": { "str": "mantle of shadows", "str_pl": "mantles of shadows" },
     "//": "misc properties were mostly made by averaging the values of all possible types of robe usable to make it, but no storage due to nested containers being buggy",
     "description": "A loose-fitting robe of some sort, heavily altered with decorations resting on the shoulders, dyed in a simple dark gray.  Activating it will grant invisibility, constantly draining essence while in use.",
     "price": "900 USD",
     "price_postapoc": "70 USD",
-    "material": [
-      "cotton"
-    ],
+    "material": [ "cotton" ],
     "color": "dark_gray",
     "charges_per_use": 1,
     "tool_ammo": "essence_type",
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "essence_type": 20
-        }
-      }
-    ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_type": 20 } } ],
     "use_action": [
       {
         "target": "robe_shadow_on",
@@ -719,59 +337,20 @@
         "ammo_scale": 0
       }
     ],
-    "relative": {
-      "weight": "616 g"
-    },
-    "extend": {
-      "flags": [
-        "NO_SALVAGE",
-        "TRADER_KEEP_EQUIPPED"
-      ]
-    },
+    "relative": { "weight": "616 g" },
+    "extend": { "flags": [ "NO_SALVAGE", "TRADER_KEEP_EQUIPPED" ] },
     "material_thickness": 6,
-    "armor": [
-      {
-        "covers": [
-          "torso",
-          "leg_l",
-          "leg_r",
-          "arm_l",
-          "arm_r"
-        ],
-        "coverage": 85,
-        "encumbrance": [
-          7,
-          7
-        ]
-      }
-    ],
-    "passive_effects": [
-      {
-        "has": "WORN",
-        "condition": "ACTIVE",
-        "ench_effects": [
-          {
-            "effect": "arcana_invis_lesser",
-            "intensity": 1
-          }
-        ]
-      }
-    ]
+    "armor": [ { "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ], "coverage": 85, "encumbrance": [ 7, 7 ] } ],
+    "passive_effects": [ { "has": "WORN", "condition": "ACTIVE", "ench_effects": [ { "effect": "arcana_invis_lesser", "intensity": 1 } ] } ]
   },
   {
     "id": "robe_shadow_on",
     "copy-from": "robe_shadow",
     "repairs_like": "robe_shadow",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL",
-      "ARMOR"
-    ],
+    "subtypes": [ "TOOL", "ARMOR" ],
     "category": "armor",
-    "name": {
-      "str": "mantle of shadows (on)",
-      "str_pl": "mantles of shadows (on)"
-    },
+    "name": { "str": "mantle of shadows (on)", "str_pl": "mantles of shadows (on)" },
     "description": "A loose-fitting robe of some sort, heavily altered with decorations resting on the shoulders.  The air wavers around it, barely noticeable to you.",
     "turns_per_charge": 300,
     "revert_to": "robe_shadow",
@@ -789,38 +368,22 @@
   {
     "id": "robe_shadow_xl",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL",
-      "ARMOR",
-      "ARTIFACT"
-    ],
+    "subtypes": [ "TOOL", "ARMOR", "ARTIFACT" ],
     "category": "armor",
-    "name": {
-      "str": "illusory mantle"
-    },
+    "name": { "str": "illusory mantle" },
     "description": "A loose-fitting, short cape with decorative trim over the shoulders, dyed a simple dark gray.  Loosely fits over the shoulders even for mutant survivors.  Activating it will grant invisibility, constantly draining essence while in use.",
     "weight": "1100 g",
     "volume": "1250 ml",
     "price": "900 USD",
     "price_postapoc": "70 USD",
     "to_hit": -1,
-    "material": [
-      "cotton"
-    ],
+    "material": [ "cotton" ],
     "symbol": "[",
     "looks_like": "poncho",
     "repairs_like": "robe_shadow",
     "color": "dark_gray",
     "warmth": 20,
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "essence_type": 20
-        }
-      }
-    ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_type": 20 } } ],
     "charges_per_use": 1,
     "tool_ammo": "essence_type",
     "use_action": [
@@ -836,48 +399,19 @@
         "ammo_scale": 0
       }
     ],
-    "flags": [
-      "OVERSIZE",
-      "OUTER",
-      "NO_SALVAGE"
-    ],
+    "flags": [ "OVERSIZE", "OUTER", "NO_SALVAGE" ],
     "material_thickness": 6,
-    "armor": [
-      {
-        "encumbrance": 7,
-        "coverage": 85,
-        "covers": [
-          "torso"
-        ]
-      }
-    ],
-    "passive_effects": [
-      {
-        "has": "WORN",
-        "condition": "ACTIVE",
-        "ench_effects": [
-          {
-            "effect": "arcana_invis_lesser",
-            "intensity": 1
-          }
-        ]
-      }
-    ]
+    "armor": [ { "encumbrance": 7, "coverage": 85, "covers": [ "torso" ] } ],
+    "passive_effects": [ { "has": "WORN", "condition": "ACTIVE", "ench_effects": [ { "effect": "arcana_invis_lesser", "intensity": 1 } ] } ]
   },
   {
     "id": "robe_shadow_xl_on",
     "copy-from": "robe_shadow_xl",
     "repairs_like": "robe_shadow",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL",
-      "ARMOR"
-    ],
+    "subtypes": [ "TOOL", "ARMOR" ],
     "category": "armor",
-    "name": {
-      "str": "illusory mantle (on)",
-      "str_pl": "illusory mantles (on)"
-    },
+    "name": { "str": "illusory mantle (on)", "str_pl": "illusory mantles (on)" },
     "description": "A loose-fitting, short cape with decorative trim over the shoulders, dyed a simple dark gray.  Loosely fits over the shoulders even for mutant survivors.  The air wavers around it, barely noticeable to you.",
     "turns_per_charge": 300,
     "revert_to": "robe_shadow_xl",
@@ -896,31 +430,13 @@
     "id": "gauntlets_necro",
     "copy-from": "platemail_gauntlets",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL",
-      "ARMOR"
-    ],
-    "name": {
-      "str": "pair of thunder gauntlets",
-      "str_pl": "pairs of thunder gauntlets"
-    },
+    "subtypes": [ "TOOL", "ARMOR" ],
+    "name": { "str": "pair of thunder gauntlets", "str_pl": "pairs of thunder gauntlets" },
     "description": "A heavy set of plate gauntlets, decorated with silver around the edges of each individual plate.  Touching the bare metal sends a faint electric tingle through you.  Use them to give a nearby enemy a powerful stunning jolt, draining health from your target.",
     "price": "600 USD",
     "price_postapoc": "50 USD",
-    "material": [
-      "steel",
-      "steel_chain",
-      "silver"
-    ],
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "essence_type": 4
-        }
-      }
-    ],
+    "material": [ "steel", "steel_chain", "silver" ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_type": 4 } } ],
     "charges_per_use": 1,
     "tool_ammo": "essence_type",
     "use_action": [
@@ -935,44 +451,18 @@
     "armor": [
       {
         "material": [
-          {
-            "type": "steel",
-            "covered_by_mat": 95,
-            "thickness": 1.25
-          },
-          {
-            "type": "steel_chain",
-            "covered_by_mat": 100,
-            "thickness": 1.2
-          },
-          {
-            "type": "leather",
-            "covered_by_mat": 100,
-            "thickness": 0.05
-          },
-          {
-            "type": "silver",
-            "covered_by_mat": 20,
-            "thickness": 0.05
-          }
+          { "type": "steel", "covered_by_mat": 95, "thickness": 1.25 },
+          { "type": "steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
+          { "type": "leather", "covered_by_mat": 100, "thickness": 0.05 },
+          { "type": "silver", "covered_by_mat": 20, "thickness": 0.05 }
         ],
-        "covers": [
-          "hand_l",
-          "hand_r"
-        ],
+        "covers": [ "hand_l", "hand_r" ],
         "coverage": 100,
         "encumbrance": 16
       }
     ],
-    "relative": {
-      "weight": "210 g"
-    },
-    "extend": {
-      "flags": [
-        "NO_SALVAGE",
-        "TRADER_KEEP_EQUIPPED"
-      ]
-    }
+    "relative": { "weight": "210 g" },
+    "extend": { "flags": [ "NO_SALVAGE", "TRADER_KEEP_EQUIPPED" ] }
   },
   {
     "id": "gauntlets_necro_xl",
@@ -980,31 +470,14 @@
     "looks_like": "gauntlets_necro",
     "repairs_like": "gauntlets_necro",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL",
-      "ARMOR"
-    ],
-    "name": {
-      "str_sp": "thunder demi-gaunts"
-    },
+    "subtypes": [ "TOOL", "ARMOR" ],
+    "name": { "str_sp": "thunder demi-gaunts" },
     "description": "Heavy fingerless plate gauntlets, decorated with silver and leaving the user free to wear them even if they have claws or other mutations, or over gloves.  Touching the bare metal sends a faint electric tingle through you.  Use them to give a nearby enemy a powerful stunning jolt, draining health from your target.",
     "price": "600 USD",
     "price_postapoc": "50 USD",
-    "material": [
-      "steel",
-      "steel_chain",
-      "silver"
-    ],
+    "material": [ "steel", "steel_chain", "silver" ],
     "warmth": 15,
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "essence_type": 4
-        }
-      }
-    ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_type": 4 } } ],
     "charges_per_use": 1,
     "tool_ammo": "essence_type",
     "use_action": [
@@ -1019,79 +492,33 @@
     "armor": [
       {
         "material": [
-          {
-            "type": "steel",
-            "covered_by_mat": 60,
-            "thickness": 1.25
-          },
-          {
-            "type": "steel_chain",
-            "covered_by_mat": 100,
-            "thickness": 1.2
-          },
-          {
-            "type": "leather",
-            "covered_by_mat": 100,
-            "thickness": 1
-          },
-          {
-            "type": "silver",
-            "covered_by_mat": 20,
-            "thickness": 0.05
-          }
+          { "type": "steel", "covered_by_mat": 60, "thickness": 1.25 },
+          { "type": "steel_chain", "covered_by_mat": 100, "thickness": 1.2 },
+          { "type": "leather", "covered_by_mat": 100, "thickness": 1 },
+          { "type": "silver", "covered_by_mat": 20, "thickness": 0.05 }
         ],
-        "covers": [
-          "hand_l",
-          "hand_r"
-        ],
+        "covers": [ "hand_l", "hand_r" ],
         "coverage": 100,
         "encumbrance": 12
       }
     ],
-    "relative": {
-      "weight": "120 g"
-    },
-    "extend": {
-      "flags": [
-        "NO_SALVAGE",
-        "ALLOWS_NATURAL_ATTACKS",
-        "OVERSIZE",
-        "OUTER"
-      ]
-    }
+    "relative": { "weight": "120 g" },
+    "extend": { "flags": [ "NO_SALVAGE", "ALLOWS_NATURAL_ATTACKS", "OVERSIZE", "OUTER" ] }
   },
   {
     "id": "cyclopean_mirror",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL",
-      "ARMOR",
-      "ARTIFACT"
-    ],
-    "name": {
-      "str": "cyclopean mirror"
-    },
+    "subtypes": [ "TOOL", "ARMOR", "ARTIFACT" ],
+    "name": { "str": "cyclopean mirror" },
     "category": "armor",
     "description": "An ornate round mirror in an archaic style, unnaturally light for its size.  Natural scenery appears to be engraved into it, and light reflected from it projects a completely different, otherworldly pattern.  It is capable of moving on its own when equipped, blocking melee attacks like a small shield.  When fueled by essence, it projects a barrier that provides minor physical defense to the entire body, negates electricity and radiation, halves other forms of elemental damage, and grants partial resistance to psychic influence and extreme temperatures.",
     "weight": "500 g",
     "volume": "4 L",
     "price": "900 USD",
     "price_postapoc": "90 USD",
-    "melee_damage": {
-      "bash": 8
-    },
-    "material": [
-      "iron"
-    ],
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "essence_type": 25
-        }
-      }
-    ],
+    "melee_damage": { "bash": 8 },
+    "material": [ "iron" ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_type": 25 } } ],
     "symbol": "[",
     "looks_like": "shield_round",
     "color": "light_gray",
@@ -1110,9 +537,7 @@
         "ammo_scale": 0
       }
     ],
-    "techniques": [
-      "WBLOCK_3"
-    ],
+    "techniques": [ "WBLOCK_3" ],
     "flags": [
       "ALLOWS_NATURAL_ATTACKS",
       "OVERSIZE",
@@ -1126,62 +551,21 @@
     ],
     "sided": true,
     "material_thickness": 4,
-    "armor": [
-      {
-        "encumbrance": 10,
-        "coverage": 80,
-        "covers": [
-          "arm_l",
-          "arm_r",
-          "hand_l",
-          "hand_r"
-        ]
-      }
-    ],
+    "armor": [ { "encumbrance": 10, "coverage": 80, "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ] } ],
     "passive_effects": [
       {
         "has": "WORN",
         "condition": "ACTIVE",
         "incoming_damage_mod": [
-          {
-            "type": "bash",
-            "add": -10
-          },
-          {
-            "type": "cut",
-            "add": -10
-          },
-          {
-            "type": "stab",
-            "add": -10
-          },
-          {
-            "type": "bullet",
-            "add": -10
-          },
-          {
-            "type": "heat",
-            "multiply": -0.5
-          },
-          {
-            "type": "cold",
-            "multiply": -0.5
-          },
-          {
-            "type": "acid",
-            "multiply": -0.5
-          }
+          { "type": "bash", "add": -10 },
+          { "type": "cut", "add": -10 },
+          { "type": "stab", "add": -10 },
+          { "type": "bullet", "add": -10 },
+          { "type": "heat", "multiply": -0.5 },
+          { "type": "cold", "multiply": -0.5 },
+          { "type": "acid", "multiply": -0.5 }
         ],
-        "values": [
-          {
-            "value": "CLIMATE_CONTROL_HEAT",
-            "add": 50
-          },
-          {
-            "value": "CLIMATE_CONTROL_CHILL",
-            "add": 50
-          }
-        ]
+        "values": [ { "value": "CLIMATE_CONTROL_HEAT", "add": 50 }, { "value": "CLIMATE_CONTROL_CHILL", "add": 50 } ]
       }
     ]
   },
@@ -1189,13 +573,8 @@
     "id": "cyclopean_mirror_on",
     "copy-from": "cyclopean_mirror",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL",
-      "ARMOR"
-    ],
-    "name": {
-      "str": "cyclopean mirror (on)"
-    },
+    "subtypes": [ "TOOL", "ARMOR" ],
+    "name": { "str": "cyclopean mirror (on)" },
     "category": "armor",
     "description": "An ornate round mirror in an archaic style.  It casts a brightly-glowing barrier that protects the user from electricity and radiation, along with partial protection from psychic influence, some resistance to extreme temperatures, increased physical resistance, and halved damage from other elemental damage.",
     "turns_per_charge": 600,
@@ -1207,9 +586,9 @@
       "type": "transform",
       "ammo_scale": 0
     },
+    "light": 480,
     "extend": {
       "flags": [
-        "LIGHT_60",
         "NO_TAKEOFF",
         "PSYSHIELD_PARTIAL",
         "RAD_PROOF",
@@ -1227,34 +606,15 @@
   {
     "id": "hauberk_jade",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL",
-      "ARMOR",
-      "ARTIFACT"
-    ],
+    "subtypes": [ "TOOL", "ARMOR", "ARTIFACT" ],
     "copy-from": "chainmail_hauberk",
-    "name": {
-      "str": "jade hauberk"
-    },
+    "name": { "str": "jade hauberk" },
     "description": "A set of mail armor with a mantle made from a gilded aegis draped over it, splints of copper worked into the arms and sides.  Underneath the mantle is a gorget of copper, with otherworldly green stones set into it.  The copper conducts electric shocks around you, providing passive immunity to lightning.  Activating it will grant immunity to fire and blade, reduce ballistic damage to one-tenth what you would normally take, and give resistance to other environmental hazards.",
     "//": "Requires an item that did not exist pre-cataclysm to make.",
     "price_postapoc": "150 USD",
-    "material": [
-      "iron",
-      "copper",
-      "leather",
-      "cotton"
-    ],
+    "material": [ "iron", "copper", "leather", "cotton" ],
     "color": "light_red",
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "essence_dull_type": 300
-        }
-      }
-    ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_dull_type": 300 } } ],
     "tool_ammo": "essence_dull_type",
     "use_action": [
       {
@@ -1276,77 +636,27 @@
         "need_worn": true
       }
     ],
-    "relative": {
-      "weight": "3020 g",
-      "price": "550 USD"
-    },
-    "extend": {
-      "flags": [
-        "NO_SALVAGE",
-        "ELECTRIC_IMMUNE",
-        "RAINPROOF",
-        "TRADER_KEEP_EQUIPPED"
-      ]
-    },
+    "relative": { "weight": "3020 g", "price": "550 USD" },
+    "extend": { "flags": [ "NO_SALVAGE", "ELECTRIC_IMMUNE", "RAINPROOF", "TRADER_KEEP_EQUIPPED" ] },
     "material_thickness": 7,
     "environmental_protection": 1,
-    "armor": [
-      {
-        "encumbrance": 20,
-        "coverage": 100,
-        "covers": [
-          "torso",
-          "arm_l",
-          "arm_r",
-          "leg_l",
-          "leg_r"
-        ]
-      }
-    ],
+    "armor": [ { "encumbrance": 20, "coverage": 100, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ] } ],
     "passive_effects": [
       {
         "has": "WORN",
         "condition": "ACTIVE",
-        "incoming_damage_mod": [
-          {
-            "type": "heat",
-            "multiply": -1
-          },
-          {
-            "type": "stab",
-            "multiply": -1
-          },
-          {
-            "type": "bullet",
-            "multiply": -0.9
-          }
-        ],
-        "values": [
-          {
-            "value": "CLIMATE_CONTROL_HEAT",
-            "add": 50
-          },
-          {
-            "value": "CLIMATE_CONTROL_CHILL",
-            "add": 50
-          }
-        ]
+        "incoming_damage_mod": [ { "type": "heat", "multiply": -1 }, { "type": "stab", "multiply": -1 }, { "type": "bullet", "multiply": -0.9 } ],
+        "values": [ { "value": "CLIMATE_CONTROL_HEAT", "add": 50 }, { "value": "CLIMATE_CONTROL_CHILL", "add": 50 } ]
       }
     ]
   },
   {
     "id": "hauberk_jade_on",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL",
-      "ARMOR"
-    ],
+    "subtypes": [ "TOOL", "ARMOR" ],
     "copy-from": "hauberk_jade",
     "repairs_like": "hauberk_jade",
-    "name": {
-      "str": "jade hauberk (on)",
-      "str_pl": "jade hauberks (on)"
-    },
+    "name": { "str": "jade hauberk (on)", "str_pl": "jade hauberks (on)" },
     "description": "A set of mail armor with a mantle made from a gilded aegis draped over it, splints of copper worked into the arms and sides.  Underneath the mantle is a gorget of copper, with otherworldly green stones set into it.  In addition to protecting against lightning, an aura of protective magic is radiating from it, granting immunity to fire and blade, reducing ballistic damage to one-tenth what you would normally take, and giving resistance to other environmental hazards.",
     "environmental_protection": 10,
     "turns_per_charge": 10,
@@ -1357,71 +667,32 @@
       "type": "transform",
       "ammo_scale": 0
     },
-    "qualities": [
-      [
-        "GLARE",
-        1
-      ]
-    ],
-    "extend": {
-      "flags": [
-        "GAS_PROOF",
-        "RAD_PROOF",
-        "SUN_GLASSES",
-        "BULLET_IMMUNE",
-        "STAB_IMMUNE",
-        "HEAT_IMMUNE"
-      ]
-    }
+    "qualities": [ [ "GLARE", 1 ] ],
+    "extend": { "flags": [ "GAS_PROOF", "RAD_PROOF", "SUN_GLASSES", "BULLET_IMMUNE", "STAB_IMMUNE", "HEAT_IMMUNE" ] }
   },
   {
     "id": "armor_wyrm_berserker",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL",
-      "ARMOR",
-      "ARTIFACT"
-    ],
-    "name": {
-      "str": "abyssal armor"
-    },
+    "subtypes": [ "TOOL", "ARMOR", "ARTIFACT" ],
+    "name": { "str": "abyssal armor" },
     "description": "What was once a modified suit of leather armor, now radically altered with heavy steel and unnatural magic made from desecrating a holy relic.  Fully covering the body with plates that shift to accommodate the user's form, just wearing it makes the user look inhuman.  Fueling it with blood essence will suppress pain and rapidly stabilize broken limbs, along with increasing the user's attack speed and reflexes.  However, its use will tax fatigue and healthiness over time, along with attracting attention both mundane and otherworldly.",
     "weight": "20 kg",
     "volume": "15 L",
     "price": "900 USD",
     "price_postapoc": "60 USD",
     "to_hit": -5,
-    "melee_damage": {
-      "bash": 8
-    },
-    "material": [
-      "steel",
-      "wyrmskin"
-    ],
+    "melee_damage": { "bash": 8 },
+    "material": [ "steel", "wyrmskin" ],
     "symbol": "[",
     "looks_like": "armor_wyrm",
     "color": "light_gray",
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "essence_blood_type": 30
-        }
-      }
-    ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_blood_type": 30 } } ],
     "tool_ammo": "essence_blood_type",
     "warmth": 20,
     "//": "Increased to be more on par with BN version's armor values.",
     "material_thickness": 5,
     "environmental_protection": 8,
-    "flags": [
-      "OUTER",
-      "STURDY",
-      "NO_SALVAGE",
-      "OVERSIZE",
-      "ALLOWS_NATURAL_ATTACKS"
-    ],
+    "flags": [ "OUTER", "STURDY", "NO_SALVAGE", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS" ],
     "use_action": [
       {
         "target": "armor_wyrm_berserker_on",
@@ -1438,108 +709,49 @@
     "armor": [
       {
         "material": [
-          {
-            "type": "steel",
-            "covered_by_mat": 95,
-            "thickness": 3
-          },
-          {
-            "type": "wyrmskin",
-            "covered_by_mat": 100,
-            "thickness": 2
-          }
+          { "type": "steel", "covered_by_mat": 95, "thickness": 3 },
+          { "type": "wyrmskin", "covered_by_mat": 100, "thickness": 2 }
         ],
-        "covers": [
-          "torso"
-        ],
+        "covers": [ "torso" ],
         "coverage": 100,
         "encumbrance": 17
       },
       {
         "material": [
-          {
-            "type": "steel",
-            "covered_by_mat": 95,
-            "thickness": 1.3
-          },
-          {
-            "type": "wyrmskin",
-            "covered_by_mat": 100,
-            "thickness": 2
-          }
+          { "type": "steel", "covered_by_mat": 95, "thickness": 1.3 },
+          { "type": "wyrmskin", "covered_by_mat": 100, "thickness": 2 }
         ],
-        "covers": [
-          "arm_l",
-          "arm_r",
-          "leg_l",
-          "leg_r"
-        ],
+        "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ],
         "coverage": 100,
         "encumbrance": 12
       },
       {
         "material": [
-          {
-            "type": "steel",
-            "covered_by_mat": 95,
-            "thickness": 1.3
-          },
-          {
-            "type": "wyrmskin",
-            "covered_by_mat": 100,
-            "thickness": 1.5
-          }
+          { "type": "steel", "covered_by_mat": 95, "thickness": 1.3 },
+          { "type": "wyrmskin", "covered_by_mat": 100, "thickness": 1.5 }
         ],
-        "covers": [
-          "hand_l",
-          "hand_r",
-          "foot_l",
-          "foot_r"
-        ],
+        "covers": [ "hand_l", "hand_r", "foot_l", "foot_r" ],
         "coverage": 100,
         "encumbrance": 8
       },
       {
         "material": [
-          {
-            "type": "steel",
-            "covered_by_mat": 100,
-            "thickness": 1.3
-          },
-          {
-            "type": "wyrmskin",
-            "covered_by_mat": 100,
-            "thickness": 1.5
-          }
+          { "type": "steel", "covered_by_mat": 100, "thickness": 1.3 },
+          { "type": "wyrmskin", "covered_by_mat": 100, "thickness": 1.5 }
         ],
-        "covers": [
-          "head"
-        ],
+        "covers": [ "head" ],
         "coverage": 100,
         "encumbrance": 20
       },
       {
         "material": [
-          {
-            "type": "steel",
-            "covered_by_mat": 100,
-            "thickness": 1.3
-          },
-          {
-            "type": "wyrmskin",
-            "covered_by_mat": 100,
-            "thickness": 1
-          }
+          { "type": "steel", "covered_by_mat": 100, "thickness": 1.3 },
+          { "type": "wyrmskin", "covered_by_mat": 100, "thickness": 1 }
         ],
-        "covers": [
-          "eyes",
-          "mouth"
-        ],
+        "covers": [ "eyes", "mouth" ],
         "coverage": 100,
         "encumbrance": 10,
-        "layers": [
-          "NORMAL"
-        ],
+        "layers": [ "NORMAL" ],
         "rigid_layer_only": true
       }
     ],
@@ -1547,23 +759,8 @@
       {
         "has": "WORN",
         "condition": "ACTIVE",
-        "mutations": [
-          "ARCANA_BERSERK_ARMOR_EFFECT"
-        ],
-        "values": [
-          {
-            "value": "INTELLIGENCE",
-            "add": -2
-          },
-          {
-            "value": "PERCEPTION",
-            "add": -2
-          },
-          {
-            "value": "BONUS_DODGE",
-            "add": 1
-          }
-        ],
+        "mutations": [ "ARCANA_BERSERK_ARMOR_EFFECT" ],
+        "values": [ { "value": "INTELLIGENCE", "add": -2 }, { "value": "PERCEPTION", "add": -2 }, { "value": "BONUS_DODGE", "add": 1 } ],
         "hit_me_effect": [
           {
             "id": "arcana_react_satchel_attention",
@@ -1573,12 +770,7 @@
             "npc_message": "A strange aura of malice seems to briefly surround %1$s."
           }
         ],
-        "ench_effects": [
-          {
-            "effect": "arcana_wyrm_berserker_decay",
-            "intensity": 1
-          }
-        ]
+        "ench_effects": [ { "effect": "arcana_wyrm_berserker_decay", "intensity": 1 } ]
       }
     ]
   },
@@ -1586,151 +778,69 @@
     "id": "armor_wyrm_berserker_on",
     "copy-from": "armor_wyrm_berserker",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL",
-      "ARMOR"
-    ],
-    "name": {
-      "str": "abyssal armor (on)",
-      "str_pl": "abyssal armors (on)"
-    },
+    "subtypes": [ "TOOL", "ARMOR" ],
+    "name": { "str": "abyssal armor (on)", "str_pl": "abyssal armors (on)" },
     "description": "What was once a modified suit of leather armor, now radically altered with heavy armor and unnatural magic made from desecrating a holy relic.  It feels like it has a will of its own with how easy it is to move in this, currently helping to stave off pain and set broken limbs, along with increasing attack speed and reflexes.  A sickening aura wearing down on body and mind can also be felt, along with the feeling of being watched.",
-    "extend": {
-      "flags": [
-        "NO_TAKEOFF",
-        "TRADER_AVOID",
-        "SPLINT"
-      ]
-    },
+    "extend": { "flags": [ "NO_TAKEOFF", "TRADER_AVOID", "SPLINT" ] },
     "armor": [
       {
         "material": [
-          {
-            "type": "steel",
-            "covered_by_mat": 95,
-            "thickness": 3
-          },
-          {
-            "type": "wyrmskin",
-            "covered_by_mat": 100,
-            "thickness": 2
-          }
+          { "type": "steel", "covered_by_mat": 95, "thickness": 3 },
+          { "type": "wyrmskin", "covered_by_mat": 100, "thickness": 2 }
         ],
-        "covers": [
-          "torso"
-        ],
+        "covers": [ "torso" ],
         "coverage": 100,
         "encumbrance": 9
       },
       {
         "material": [
-          {
-            "type": "steel",
-            "covered_by_mat": 95,
-            "thickness": 1.3
-          },
-          {
-            "type": "wyrmskin",
-            "covered_by_mat": 100,
-            "thickness": 2
-          }
+          { "type": "steel", "covered_by_mat": 95, "thickness": 1.3 },
+          { "type": "wyrmskin", "covered_by_mat": 100, "thickness": 2 }
         ],
-        "covers": [
-          "arm_l",
-          "arm_r",
-          "leg_l",
-          "leg_r"
-        ],
+        "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ],
         "coverage": 100,
         "encumbrance": 6
       },
       {
         "material": [
-          {
-            "type": "steel",
-            "covered_by_mat": 95,
-            "thickness": 1.3
-          },
-          {
-            "type": "wyrmskin",
-            "covered_by_mat": 100,
-            "thickness": 1.5
-          }
+          { "type": "steel", "covered_by_mat": 95, "thickness": 1.3 },
+          { "type": "wyrmskin", "covered_by_mat": 100, "thickness": 1.5 }
         ],
-        "covers": [
-          "hand_l",
-          "hand_r",
-          "foot_l",
-          "foot_r"
-        ],
+        "covers": [ "hand_l", "hand_r", "foot_l", "foot_r" ],
         "coverage": 100,
         "encumbrance": 4
       },
       {
         "material": [
-          {
-            "type": "steel",
-            "covered_by_mat": 100,
-            "thickness": 1.3
-          },
-          {
-            "type": "wyrmskin",
-            "covered_by_mat": 100,
-            "thickness": 1.5
-          }
+          { "type": "steel", "covered_by_mat": 100, "thickness": 1.3 },
+          { "type": "wyrmskin", "covered_by_mat": 100, "thickness": 1.5 }
         ],
-        "covers": [
-          "head"
-        ],
+        "covers": [ "head" ],
         "coverage": 100,
         "encumbrance": 10
       },
       {
         "material": [
-          {
-            "type": "steel",
-            "covered_by_mat": 100,
-            "thickness": 1.3
-          },
-          {
-            "type": "wyrmskin",
-            "covered_by_mat": 100,
-            "thickness": 1
-          }
+          { "type": "steel", "covered_by_mat": 100, "thickness": 1.3 },
+          { "type": "wyrmskin", "covered_by_mat": 100, "thickness": 1 }
         ],
-        "covers": [
-          "eyes",
-          "mouth"
-        ],
+        "covers": [ "eyes", "mouth" ],
         "coverage": 100,
         "encumbrance": 10,
-        "layers": [
-          "OUTER"
-        ],
+        "layers": [ "OUTER" ],
         "rigid_layer_only": true
       }
     ],
     "turns_per_charge": 100,
     "revert_to": "armor_wyrm_berserker",
-    "use_action": {
-      "target": "armor_wyrm_berserker",
-      "msg": "The armor's unnatural aura fades.",
-      "type": "transform",
-      "ammo_scale": 0
-    }
+    "use_action": { "target": "armor_wyrm_berserker", "msg": "The armor's unnatural aura fades.", "type": "transform", "ammo_scale": 0 }
   },
   {
     "id": "jade_wreath",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL",
-      "ARMOR",
-      "ARTIFACT"
-    ],
+    "subtypes": [ "TOOL", "ARMOR", "ARTIFACT" ],
     "category": "clothing",
-    "name": {
-      "str": "jade wreath"
-    },
+    "name": { "str": "jade wreath" },
     "description": "A crown of dark green stone with strange geometric patterns carved into it.  Activating it will harden the body against heat and smoke, consuming blood essence while it's in effect.",
     "//": "The shrine lesser artifacts are all post-cataclysm items.",
     "price_postapoc": "100 USD",
@@ -1738,22 +848,12 @@
     "volume": "3 L",
     "price": "900 USD",
     "to_hit": -1,
-    "material": [
-      "stone"
-    ],
+    "material": [ "stone" ],
     "symbol": "[",
     "looks_like": "crown_golden",
     "repairs_like": "revenant_crown",
     "color": "green",
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "essence_blood_type": 30
-        }
-      }
-    ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_blood_type": 30 } } ],
     "tool_ammo": "essence_blood_type",
     "use_action": {
       "target": "jade_wreath_on",
@@ -1766,65 +866,26 @@
       "type": "transform",
       "ammo_scale": 0
     },
-    "flags": [
-      "BELTED",
-      "OVERSIZE",
-      "ALLOWS_NATURAL_ATTACKS",
-      "TRADER_KEEP_EQUIPPED",
-      "POWERARMOR_COMPATIBLE"
-    ],
+    "flags": [ "BELTED", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "TRADER_KEEP_EQUIPPED", "POWERARMOR_COMPATIBLE" ],
     "material_thickness": 1,
-    "armor": [
-      {
-        "encumbrance": 10,
-        "coverage": 20,
-        "covers": [
-          "head"
-        ]
-      }
-    ],
+    "armor": [ { "encumbrance": 10, "coverage": 20, "covers": [ "head" ] } ],
     "passive_effects": [
       {
         "has": "WORN",
         "condition": "ACTIVE",
-        "incoming_damage_mod": [
-          {
-            "type": "heat",
-            "multiply": -0.5
-          }
-        ],
-        "values": [
-          {
-            "value": "CLIMATE_CONTROL_HEAT",
-            "add": 50
-          },
-          {
-            "value": "CLIMATE_CONTROL_CHILL",
-            "add": 50
-          }
-        ],
-        "ench_effects": [
-          {
-            "effect": "heat_ward",
-            "intensity": 1
-          }
-        ]
+        "incoming_damage_mod": [ { "type": "heat", "multiply": -0.5 } ],
+        "values": [ { "value": "CLIMATE_CONTROL_HEAT", "add": 50 }, { "value": "CLIMATE_CONTROL_CHILL", "add": 50 } ],
+        "ench_effects": [ { "effect": "heat_ward", "intensity": 1 } ]
       }
     ]
   },
   {
     "id": "jade_wreath_on",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL",
-      "ARMOR"
-    ],
+    "subtypes": [ "TOOL", "ARMOR" ],
     "copy-from": "jade_wreath",
     "repairs_like": "jade_wreath",
-    "name": {
-      "str": "jade wreath (on)",
-      "str_pl": "jade wreaths (on)"
-    },
+    "name": { "str": "jade wreath (on)", "str_pl": "jade wreaths (on)" },
     "description": "A crown of dark green stone with strange geometric patterns carved into it.  It is currently active, completely protecting you against heat and smoke.",
     "turns_per_charge": 150,
     "revert_to": "jade_wreath",
@@ -1834,45 +895,24 @@
       "type": "transform",
       "ammo_scale": 0
     },
-    "extend": {
-      "flags": [
-        "TRADER_AVOID",
-        "NO_TAKEOFF"
-      ]
-    }
+    "extend": { "flags": [ "TRADER_AVOID", "NO_TAKEOFF" ] }
   },
   {
     "id": "meteoric_talisman",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL",
-      "ARMOR",
-      "ARTIFACT"
-    ],
-    "name": {
-      "str": "meteoric talisman"
-    },
+    "subtypes": [ "TOOL", "ARMOR", "ARTIFACT" ],
+    "name": { "str": "meteoric talisman" },
     "category": "armor",
     "description": "An ornate necklace with a small charm resembling a round shield, made from a hard iridescent metal.  Activating it will ward against electricity at the expense of slowing you down slightly, consuming dull essence while active.",
     "weight": "60 g",
     "volume": "250 ml",
     "price_postapoc": "100 USD",
-    "material": [
-      "steel"
-    ],
+    "material": [ "steel" ],
     "symbol": "[",
     "looks_like": "jade_brooch",
     "repairs_like": "mana_gem",
     "color": "light_gray",
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "essence_dull_type": 300
-        }
-      }
-    ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_dull_type": 300 } } ],
     "tool_ammo": "essence_dull_type",
     "use_action": {
       "target": "meteoric_talisman_on",
@@ -1885,37 +925,16 @@
       "type": "transform",
       "ammo_scale": 0
     },
-    "flags": [
-      "FANCY",
-      "NO_SALVAGE",
-      "TRADER_KEEP_EQUIPPED"
-    ],
-    "passive_effects": [
-      {
-        "has": "WORN",
-        "condition": "ACTIVE",
-        "ench_effects": [
-          {
-            "effect": "lightning_ward",
-            "intensity": 1
-          }
-        ]
-      }
-    ]
+    "flags": [ "FANCY", "NO_SALVAGE", "TRADER_KEEP_EQUIPPED" ],
+    "passive_effects": [ { "has": "WORN", "condition": "ACTIVE", "ench_effects": [ { "effect": "lightning_ward", "intensity": 1 } ] } ]
   },
   {
     "id": "meteoric_talisman_on",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL",
-      "ARMOR"
-    ],
+    "subtypes": [ "TOOL", "ARMOR" ],
     "copy-from": "meteoric_talisman",
     "repairs_like": "meteoric_talisman",
-    "name": {
-      "str": "meteoric talisman (on)",
-      "str_pl": "meteoric talismans (on)"
-    },
+    "name": { "str": "meteoric talisman (on)", "str_pl": "meteoric talismans (on)" },
     "description": "An ornate necklace with a small charm resembling a round shield, made from a hard iridescent metal.  It is currently activate, insulating you against electrical attacks but also slowing you down a bit.",
     "turns_per_charge": 15,
     "revert_to": "meteoric_talisman",
@@ -1925,115 +944,49 @@
       "type": "transform",
       "ammo_scale": 0
     },
-    "extend": {
-      "flags": [
-        "TRADER_AVOID",
-        "NO_TAKEOFF"
-      ]
-    }
+    "extend": { "flags": [ "TRADER_AVOID", "NO_TAKEOFF" ] }
   },
   {
     "id": "divine_sealing_charm",
     "looks_like": "small_relic",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL",
-      "ARMOR",
-      "ARTIFACT"
-    ],
+    "subtypes": [ "TOOL", "ARMOR", "ARTIFACT" ],
     "category": "tools",
-    "name": {
-      "str": "divine sealing charm"
-    },
+    "name": { "str": "divine sealing charm" },
     "description": "A silver and gold relic encircling and framing a pitch-black gem.  All across the metal are holy symbols and engraved text mixing archaic Latin, Old Norse runes, and symbols that don't seem to match any writing humans have devised.  Combining dimensional fatigue research with the knowledge of multiple arcane orders, it was made to serve the same purpose as the Keepers' relics and Project Kairos.\n\nLinger near a portal to collapse it into a form you can harvest crystallized essence from, then fuel it with crystallized essence.  Channeling this energy will create a powerful healing effect affecting you and nearby allies, remove alien influence on your surroundings, as well as restore dead plant life nearby.  Note that essence loaded into it cannot be unloaded.",
     "weight": "1200 g",
     "volume": "750 ml",
     "price_postapoc": "150 USD",
-    "material": [
-      "silver",
-      "gold",
-      "essencemat"
-    ],
+    "material": [ "silver", "gold", "essencemat" ],
     "symbol": "[",
     "color": "yellow",
     "charges_per_use": 1,
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "essence_type": 10
-        }
-      }
-    ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_type": 10 } } ],
     "tool_ammo": "essence_pure_type",
-    "use_action": [
-      {
-        "type": "cast_spell",
-        "spell_id": "arcana_item_divine_seal",
-        "no_fail": true,
-        "need_worn": true,
-        "level": 0
-      }
-    ],
-    "flags": [
-      "NO_SALVAGE",
-      "NO_UNLOAD",
-      "DIMENSIONAL_ANCHOR",
-      "PSYSHIELD_PARTIAL",
-      "PORTAL_PROOF"
-    ],
+    "use_action": [ { "type": "cast_spell", "spell_id": "arcana_item_divine_seal", "no_fail": true, "need_worn": true, "level": 0 } ],
+    "flags": [ "NO_SALVAGE", "NO_UNLOAD", "DIMENSIONAL_ANCHOR", "PSYSHIELD_PARTIAL", "PORTAL_PROOF" ],
     "passive_effects": [
       {
         "has": "WORN",
         "condition": "ALWAYS",
-        "intermittent_activation": {
-          "effects": [
-            {
-              "frequency": "3 minutes",
-              "spell_effects": [
-                {
-                  "id": "arcana_react_veilblade"
-                }
-              ]
-            }
-          ]
-        }
+        "intermittent_activation": { "effects": [ { "frequency": "3 minutes", "spell_effects": [ { "id": "arcana_react_veilblade" } ] } ] }
       }
     ]
   },
   {
     "id": "cleric_ring",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL",
-      "ARMOR",
-      "ARTIFACT"
-    ],
+    "subtypes": [ "TOOL", "ARMOR", "ARTIFACT" ],
     "copy-from": "silver_ring",
     "repairs_like": "orb_veil",
-    "name": {
-      "str": "ring of the fallen angel",
-      "str_pl": "rings of the fallen angel"
-    },
+    "name": { "str": "ring of the fallen angel", "str_pl": "rings of the fallen angel" },
     "description": "A simple silver ring, adorned with a small red gem and a wing motif.  Activating it channels a powerful protective spell, guarding against many forms of supernatural harm.",
     "//": "While unassuming, those who knew what rituals it was useful for would value it highly.  Those people are probably now dead.",
     "price": "3600 USD",
     "price_postapoc": "150 USD",
-    "material": [
-      "silver",
-      "essencemat"
-    ],
+    "material": [ "silver", "essencemat" ],
     "color": "white",
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "essence_type": 10
-        }
-      }
-    ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_type": 10 } } ],
     "tool_ammo": "essence_type",
     "use_action": {
       "target": "cleric_ring_on",
@@ -2050,50 +1003,21 @@
       {
         "encumbrance": 0,
         "coverage": 0,
-        "covers": [
-          "hand_l",
-          "hand_r"
-        ],
-        "specifically_covers": [
-          "hand_fingers_l",
-          "hand_fingers_r"
-        ],
+        "covers": [ "hand_l", "hand_r" ],
+        "specifically_covers": [ "hand_fingers_l", "hand_fingers_r" ],
         "rigid_layer_only": true
       }
     ],
-    "extend": {
-      "flags": [
-        "NO_SALVAGE",
-        "TRADER_KEEP_EQUIPPED",
-        "PSYSHIELD_PARTIAL"
-      ]
-    },
-    "passive_effects": [
-      {
-        "has": "WORN",
-        "condition": "ACTIVE",
-        "ench_effects": [
-          {
-            "effect": "cleric_warding",
-            "intensity": 1
-          }
-        ]
-      }
-    ]
+    "extend": { "flags": [ "NO_SALVAGE", "TRADER_KEEP_EQUIPPED", "PSYSHIELD_PARTIAL" ] },
+    "passive_effects": [ { "has": "WORN", "condition": "ACTIVE", "ench_effects": [ { "effect": "cleric_warding", "intensity": 1 } ] } ]
   },
   {
     "id": "cleric_ring_on",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL",
-      "ARMOR"
-    ],
+    "subtypes": [ "TOOL", "ARMOR" ],
     "copy-from": "cleric_ring",
     "repairs_like": "cleric_ring",
-    "name": {
-      "str": "ring of the fallen angel (on)",
-      "str_pl": "rings of the fallen angel (on)"
-    },
+    "name": { "str": "ring of the fallen angel (on)", "str_pl": "rings of the fallen angel (on)" },
     "description": "A simple silver ring, adorned with a small red gem and a wing motif.  The wings encircle the gem and shimmer with an eerie pale glow, its protective magic protecting against various anomalous influences.",
     "turns_per_charge": 450,
     "revert_to": "cleric_ring",
@@ -2103,13 +1027,6 @@
       "type": "transform",
       "ammo_scale": 0
     },
-    "extend": {
-      "flags": [
-        "TRADER_AVOID",
-        "NO_TAKEOFF",
-        "DIMENSIONAL_ANCHOR",
-        "PORTAL_PROOF"
-      ]
-    }
+    "extend": { "flags": [ "TRADER_AVOID", "NO_TAKEOFF", "DIMENSIONAL_ANCHOR", "PORTAL_PROOF" ] }
   }
 ]

--- a/Arcana/items/tools.json
+++ b/Arcana/items/tools.json
@@ -3,13 +3,8 @@
     "id": "tindalos_whistle",
     "copy-from": "tindalos_whistle",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
-    "name": {
-      "str": "Whistle of Tindalos",
-      "str_pl": "Whistles of Tindalos"
-    },
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "Whistle of Tindalos", "str_pl": "Whistles of Tindalos" },
     "description": "This is a small whistle, resembling a dog whistle if not for the unusual markings and exotic material it's made out of.  The strange sound it makes is clearly not meant to call canines, or anything native to this dimension for that matter.",
     "initial_charges": 1,
     "max_charges": 1,
@@ -19,12 +14,8 @@
     "id": "portal",
     "copy-from": "portal",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
-    "name": {
-      "str": "portal generator"
-    },
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "portal generator" },
     "initial_charges": 2,
     "max_charges": 2,
     "charges_per_use": 1
@@ -33,91 +24,48 @@
     "id": "bot_vortex",
     "//": "ID retained to avoid any weirdness.",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
-    "name": {
-      "str": "Archon magic"
-    },
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "Archon magic" },
     "description": "Spawns a shadow, used by the Host of the Archon.  This is a bug if you find one of these.",
-    "material": [
-      "essencemat"
-    ],
+    "material": [ "essencemat" ],
     "symbol": ",",
     "color": "cyan",
-    "use_action": {
-      "type": "place_monster",
-      "monster_id": "mon_shadow_summoned",
-      "place_randomly": true
-    },
-    "flags": [
-      "ZERO_WEIGHT"
-    ]
+    "use_action": { "type": "place_monster", "monster_id": "mon_shadow_summoned", "place_randomly": true },
+    "flags": [ "ZERO_WEIGHT" ]
   },
   {
     "id": "bot_shadows_fake",
     "//": "ID retained to avoid any weirdness.",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
-    "name": {
-      "str": "Archon magic"
-    },
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "Archon magic" },
     "description": "Spawns a fake shadow, used by the Seraphic Shade.  This is a bug if you find one of these.",
-    "material": [
-      "essencemat"
-    ],
+    "material": [ "essencemat" ],
     "symbol": ",",
     "color": "cyan",
-    "use_action": {
-      "type": "place_monster",
-      "monster_id": "mon_shadow_summoned_fake",
-      "place_randomly": true
-    },
-    "flags": [
-      "ZERO_WEIGHT"
-    ]
+    "use_action": { "type": "place_monster", "monster_id": "mon_shadow_summoned_fake", "place_randomly": true },
+    "flags": [ "ZERO_WEIGHT" ]
   },
   {
     "id": "bot_seraphic_mimic",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
-    "name": {
-      "str": "Archon mimic"
-    },
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "Archon mimic" },
     "description": "Spawns a copy of the seraphic shade.  This is a bug if you find one of these.",
-    "material": [
-      "essencemat"
-    ],
+    "material": [ "essencemat" ],
     "symbol": ",",
     "color": "cyan",
-    "use_action": {
-      "type": "place_monster",
-      "monster_id": "mon_seraphic_shade_fake",
-      "place_randomly": true
-    },
-    "flags": [
-      "ZERO_WEIGHT"
-    ]
+    "use_action": { "type": "place_monster", "monster_id": "mon_seraphic_shade_fake", "place_randomly": true },
+    "flags": [ "ZERO_WEIGHT" ]
   },
   {
     "id": "stinger_flute",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
+    "subtypes": [ "TOOL" ],
     "copy-from": "bone_flute",
-    "name": {
-      "str": "stinger flute",
-      "str_pl": "stinger flutes"
-    },
+    "name": { "str": "stinger flute", "str_pl": "stinger flutes" },
     "description": "A polished flute with five finger holes, carved from the stinger of some exotic monstrosity.  Should be safe to put up to your mouth, probably.",
-    "material": [
-      "flesh"
-    ],
+    "material": [ "flesh" ],
     "color": "light_gray",
     "//": "As noted with wearable trinkets made from monsterparts, these are post-cata only.",
     "price_postapoc": "250 cent",
@@ -139,16 +87,12 @@
   {
     "id": "charm_bone",
     "type": "ITEM",
-    "name": {
-      "str": "bone charm"
-    },
+    "name": { "str": "bone charm" },
     "description": "A small talisman made out of some form of otherworldly bone or ivory, carved with equally unearthly iconography.",
     "weight": "38 g",
     "volume": "50 ml",
     "price_postapoc": "2 USD",
-    "material": [
-      "bone"
-    ],
+    "material": [ "bone" ],
     "symbol": ",",
     "looks_like": "small_relic",
     "color": "white",
@@ -159,116 +103,52 @@
     "copy-from": "charm_bone",
     "sub": "charm_bone",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL",
-      "ARTIFACT"
-    ],
-    "name": {
-      "str": "sanctified bone charm"
-    },
+    "subtypes": [ "TOOL", "ARTIFACT" ],
+    "name": { "str": "sanctified bone charm" },
     "description": "A small talisman made out of some form of otherworldly bone or ivory, carved with equally unearthly iconography.  Elemental magic has been woven into its structure, converting it into a primitive magic item.  Using it will heavily damage and paralyze any hostiles within 4 tiles.  It will take a long time to recharge after each use, and activating it also fatigues the user.  It can hold up to 5 uses, each use takes 20 hours to charge.",
     "price_postapoc": "20 USD",
     "charges_per_use": 20,
     "tool_ammo": "primitive_magic_item_ammo_type",
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "primitive_magic_item_ammo_type": 100
-        }
-      }
-    ],
-    "flags": [
-      "MAGIC_FOCUS",
-      "NO_RELOAD",
-      "NO_UNLOAD",
-      "TARDIS"
-    ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "primitive_magic_item_ammo_type": 100 } } ],
+    "flags": [ "MAGIC_FOCUS", "NO_RELOAD", "NO_UNLOAD", "TARDIS" ],
     "//": "Flame talisman and earth talisman.  Each use has power equivalent to 200 mana.",
-    "use_action": {
-      "type": "cast_spell",
-      "spell_id": "arcana_item_charm_bone_empowered",
-      "no_fail": true,
-      "level": 0
-    },
-    "charge_info": {
-      "recharge_type": "periodic",
-      "time": "1 h",
-      "regenerate_ammo": true
-    }
+    "use_action": { "type": "cast_spell", "spell_id": "arcana_item_charm_bone_empowered", "no_fail": true, "level": 0 },
+    "charge_info": { "recharge_type": "periodic", "time": "1 h", "regenerate_ammo": true }
   },
   {
     "id": "stinger_flute_empowered",
     "copy-from": "stinger_flute",
     "sub": "stinger_flute",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL",
-      "ARTIFACT"
-    ],
-    "name": {
-      "str": "quickened stinger flute"
-    },
+    "subtypes": [ "TOOL", "ARTIFACT" ],
+    "name": { "str": "quickened stinger flute" },
     "description": "A polished flute with five finger holes, carved from the stinger of some exotic monstrosity.  Elemental magic has been woven into its structure, converting it into a primitive magic item.  Using it will greatly reduce movecosts and enhance evasion.  Stamina and attack speed are unaffected, however.  It will take a long time to recharge after each use, and activating it also fatigues the user.  It can hold up to 6 uses, each use takes 40 hours to charge.",
     "price_postapoc": "25 USD",
     "charges_per_use": 40,
     "tool_ammo": "primitive_magic_item_ammo_type",
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "primitive_magic_item_ammo_type": 200
-        }
-      }
-    ],
-    "flags": [
-      "MAGIC_FOCUS",
-      "NO_RELOAD",
-      "NO_UNLOAD",
-      "TARDIS"
-    ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "primitive_magic_item_ammo_type": 200 } } ],
+    "flags": [ "MAGIC_FOCUS", "NO_RELOAD", "NO_UNLOAD", "TARDIS" ],
     "//": "Water talisman and air talisman.  Each use has power equivalent to 400 mana.",
-    "use_action": {
-      "type": "cast_spell",
-      "spell_id": "arcana_item_stinger_flute_empowered",
-      "no_fail": true,
-      "level": 0
-    },
-    "charge_info": {
-      "recharge_type": "periodic",
-      "time": "1 h",
-      "regenerate_ammo": true
-    }
+    "use_action": { "type": "cast_spell", "spell_id": "arcana_item_stinger_flute_empowered", "no_fail": true, "level": 0 },
+    "charge_info": { "recharge_type": "periodic", "time": "1 h", "regenerate_ammo": true }
   },
   {
     "id": "offering_chalice",
     "type": "ITEM",
-    "subtypes": [
-      "ARTIFACT"
-    ],
-    "name": {
-      "str": "offering chalice"
-    },
+    "subtypes": [ "ARTIFACT" ],
+    "name": { "str": "offering chalice" },
     "description": "This is a strange chalice made of gold, engraved all over with some unfamiliar text.  It is filled with a thick black liquid that you seem unable to pour out.  Using it will allow you to perform a ritual that can convert your own life force into blood essence.  Doing so will take 15 minutes, inflicting harm upon your body at the end, as well as dire consequences if overused…",
     "weight": "2500 g",
     "volume": "1 L",
     "price": "1600 USD",
     "price_postapoc": "30 USD",
     "to_hit": -1,
-    "melee_damage": {
-      "bash": 6
-    },
-    "material": [
-      "gold"
-    ],
+    "melee_damage": { "bash": 6 },
+    "material": [ "gold" ],
     "symbol": ";",
     "looks_like": "small_relic",
     "color": "yellow",
-    "flags": [
-      "MAGIC_FOCUS"
-    ],
+    "flags": [ "MAGIC_FOCUS" ],
     "use_action": [
       "MEDITATE",
       {
@@ -279,33 +159,16 @@
         "level": 0
       }
     ],
-    "passive_effects": [
-      {
-        "has": "WIELD",
-        "condition": "ALWAYS",
-        "values": [
-          {
-            "value": "REGEN_MANA",
-            "multiply": 0.25
-          }
-        ]
-      }
-    ]
+    "passive_effects": [ { "has": "WIELD", "condition": "ALWAYS", "values": [ { "value": "REGEN_MANA", "multiply": 0.25 } ] } ]
   },
   {
     "id": "blood_athame",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
+    "subtypes": [ "TOOL" ],
     "//": "By necessity can't yet define this to use copy-from, as qualities will break it.",
     "category": "weapons",
-    "weapon_category": [
-      "KNIVES"
-    ],
-    "name": {
-      "str": "silver athame"
-    },
+    "weapon_category": [ "KNIVES" ],
+    "name": { "str": "silver athame" },
     "description": "An ornate silver dagger, seemingly made for ritual purposes.  It seems sharper than silver has any right to be.  It can be used to perform a ritual converting your life force into blood essence.  Doing so will take 5 minutes, inflicting blood loss and damage at the end, as well as potential consequences if overused…",
     "weight": "1302 g",
     "volume": "750 ml",
@@ -313,34 +176,13 @@
     "price": "240 USD",
     "price_postapoc": "20 USD",
     "to_hit": 1,
-    "melee_damage": {
-      "bash": 3,
-      "stab": 16
-    },
-    "material": [
-      "silver"
-    ],
+    "melee_damage": { "bash": 3, "stab": 16 },
+    "material": [ "silver" ],
     "symbol": "/",
     "looks_like": "knife_butcher",
     "color": "red",
-    "techniques": [
-      "WBLOCK_1",
-      "RAPID"
-    ],
-    "qualities": [
-      [
-        "CUT",
-        1
-      ],
-      [
-        "CUT_FINE",
-        2
-      ],
-      [
-        "BUTCHER",
-        15
-      ]
-    ],
+    "techniques": [ "WBLOCK_1", "RAPID" ],
+    "qualities": [ [ "CUT", 1 ], [ "CUT_FINE", 2 ], [ "BUTCHER", 15 ] ],
     "use_action": [
       {
         "type": "cast_spell",
@@ -350,24 +192,16 @@
         "level": 0
       }
     ],
-    "flags": [
-      "SHEATH_KNIFE"
-    ]
+    "flags": [ "SHEATH_KNIFE" ]
   },
   {
     "id": "sun_sword",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
+    "subtypes": [ "TOOL" ],
     "category": "weapons",
     "copy-from": "arming_sword",
-    "weapon_category": [
-      "MEDIUM_SWORDS"
-    ],
-    "name": {
-      "str": "incorruptible sword"
-    },
+    "weapon_category": [ "MEDIUM_SWORDS" ],
+    "name": { "str": "incorruptible sword" },
     "//": "Stats are a blend of the available swords you can use to make it, same deal as the mantle of shadows.",
     "description": "This is some manner of sword, decorated with a golden cross motif worked into the blade.  When powered by consecrated magical essence, it has the power to cut through darkness itself.",
     "weight": "1360 g",
@@ -376,45 +210,15 @@
     "price": "1500 USD",
     "price_postapoc": "75 USD",
     "to_hit": 2,
-    "melee_damage": {
-      "bash": 10,
-      "cut": 35
-    },
-    "material": [
-      {
-        "type": "steel",
-        "portion": 25
-      },
-      {
-        "type": "gold"
-      }
-    ],
+    "melee_damage": { "bash": 10, "cut": 35 },
+    "material": [ { "type": "steel", "portion": 25 }, { "type": "gold" } ],
     "symbol": "/",
     "looks_like": "arming_sword",
     "color": "yellow",
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "essence_dull_type": 20
-        }
-      }
-    ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_dull_type": 20 } } ],
     "tool_ammo": "essence_dull_type",
-    "qualities": [
-      [
-        "CUT",
-        1
-      ],
-      [
-        "BUTCHER",
-        10
-      ]
-    ],
-    "techniques": [
-      "WBLOCK_2"
-    ],
+    "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 10 ] ],
+    "techniques": [ "WBLOCK_2" ],
     "use_action": [
       {
         "target": "sun_sword_on",
@@ -427,38 +231,23 @@
         "ammo_scale": 0
       }
     ],
-    "flags": [
-      "DURABLE_MELEE",
-      "SHEATH_SWORD",
-      "NO_SALVAGE",
-      "TRADER_KEEP_EQUIPPED"
-    ]
+    "flags": [ "DURABLE_MELEE", "SHEATH_SWORD", "NO_SALVAGE", "TRADER_KEEP_EQUIPPED" ]
   },
   {
     "id": "sun_sword_on",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
+    "subtypes": [ "TOOL" ],
     "copy-from": "sun_sword",
     "repairs_like": "sun_sword",
     "category": "weapons",
-    "name": {
-      "str": "incorruptible sword (on)",
-      "str_pl": "incorruptible swords (on)"
-    },
+    "name": { "str": "incorruptible sword (on)", "str_pl": "incorruptible swords (on)" },
     "description": "This is some manner of sword, decorated with a golden cross motif worked into the blade.  The blade is giving off an intense white light, and searing heat.",
     "turns_per_charge": 100,
+    "light": 960,
     "revert_to": "sun_sword",
-    "techniques": [
-      "WBLOCK_2",
-      "tec_weapon_incorruptible_slash"
-    ],
+    "techniques": [ "WBLOCK_2", "tec_weapon_incorruptible_slash" ],
     "use_action": [
-      {
-        "type": "firestarter",
-        "moves": 30
-      },
+      { "type": "firestarter", "moves": 30 },
       {
         "menu_text": "Turn off",
         "type": "transform",
@@ -467,151 +256,50 @@
         "ammo_scale": 0
       }
     ],
-    "melee_damage": {
-      "bash": 10,
-      "cut": 35,
-      "heat": 6
-    },
-    "extend": {
-      "flags": [
-        "FIRE",
-        "LIGHT_240",
-        "CHARGEDIM",
-        "FLAMING",
-        "NONCONDUCTIVE"
-      ]
-    },
-    "delete": {
-      "flags": [
-        "SHEATH_SWORD"
-      ]
-    }
+    "melee_damage": { "bash": 10, "cut": 35, "heat": 6 },
+    "extend": { "flags": [ "FIRE", "CHARGEDIM", "FLAMING", "NONCONDUCTIVE" ] },
+    "delete": { "flags": [ "SHEATH_SWORD" ] }
   },
   {
     "id": "hexenhammer",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
+    "subtypes": [ "TOOL" ],
     "category": "weapons",
     "copy-from": "warhammer",
-    "name": {
-      "str": "hammer of the hunter",
-      "str_pl": "hammers of the hunter"
-    },
+    "name": { "str": "hammer of the hunter", "str_pl": "hammers of the hunter" },
     "description": "A warhammer inlaid with silver, engraved with religious invocations in an archaic form of Latin.  Many magical items can be purified with this item.  It can be used to channel consecrated essence into a stunning flash.  Though using it is a double-edged sword, it will have further effects on creatures of darkness.",
     "price": "800 USD",
     "price_postapoc": "45 USD",
-    "material": [
-      {
-        "type": "steel",
-        "portion": 25
-      },
-      {
-        "type": "wood",
-        "portion": 25
-      },
-      {
-        "type": "silver",
-        "portion": 2
-      }
-    ],
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "essence_dull_type": 3
-        }
-      }
-    ],
+    "material": [ { "type": "steel", "portion": 25 }, { "type": "wood", "portion": 25 }, { "type": "silver", "portion": 2 } ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_dull_type": 3 } } ],
     "charges_per_use": 3,
     "tool_ammo": "essence_dull_type",
-    "use_action": [
-      {
-        "type": "cast_spell",
-        "spell_id": "arcana_item_hammerzeit",
-        "no_fail": true,
-        "need_wielding": true,
-        "level": 0
-      }
-    ],
-    "relative": {
-      "weight": "360 g",
-      "melee_damage": {
-        "bash": 2
-      }
-    },
-    "extend": {
-      "flags": [
-        "NO_SALVAGE"
-      ]
-    }
+    "use_action": [ { "type": "cast_spell", "spell_id": "arcana_item_hammerzeit", "no_fail": true, "need_wielding": true, "level": 0 } ],
+    "relative": { "weight": "360 g", "melee_damage": { "bash": 2 } },
+    "extend": { "flags": [ "NO_SALVAGE" ] }
   },
   {
     "id": "spear_pestilence",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL",
-      "ARTIFACT"
-    ],
+    "subtypes": [ "TOOL", "ARTIFACT" ],
     "copy-from": "spear_steel",
     "category": "weapons",
-    "name": {
-      "str": "spear of pestilence",
-      "str_pl": "spears of pestilence"
-    },
+    "name": { "str": "spear of pestilence", "str_pl": "spears of pestilence" },
     "description": "A stout steel spear with a wicked sting, decorated with elaborate patterns carved from chitin.  Using it will blast nearby enemies with frost and temporarily summon mutant vermin to aid you, while wielding it makes movement easier.",
     "price": "1200 USD",
     "price_postapoc": "35 USD",
-    "material": [
-      "steel",
-      "wood",
-      "chitin"
-    ],
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "essence_type": 9
-        }
-      }
-    ],
+    "material": [ "steel", "wood", "chitin" ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_type": 9 } } ],
     "charges_per_use": 1,
     "tool_ammo": "essence_type",
-    "use_action": [
-      {
-        "type": "cast_spell",
-        "spell_id": "arcana_item_pestilence",
-        "no_fail": true,
-        "need_wielding": true,
-        "level": 0
-      }
-    ],
-    "relative": {
-      "weight": "540g",
-      "melee_damage": {
-        "bash": 2
-      }
-    },
-    "extend": {
-      "flags": [
-        "NO_SALVAGE",
-        "MAGIC_FOCUS",
-        "TRADER_KEEP_EQUIPPED"
-      ]
-    },
+    "use_action": [ { "type": "cast_spell", "spell_id": "arcana_item_pestilence", "no_fail": true, "need_wielding": true, "level": 0 } ],
+    "relative": { "weight": "540g", "melee_damage": { "bash": 2 } },
+    "extend": { "flags": [ "NO_SALVAGE", "MAGIC_FOCUS", "TRADER_KEEP_EQUIPPED" ] },
     "passive_effects": [
       {
         "has": "WIELD",
         "condition": "ALWAYS",
-        "values": [
-          {
-            "value": "MOVE_COST",
-            "add": -25
-          }
-        ],
+        "values": [ { "value": "MOVE_COST", "add": -25 } ],
         "hit_you_effect": [
           {
             "id": "arcana_react_spear_pestilence_poison",
@@ -626,13 +314,9 @@
   {
     "id": "blast_canister_arcana_flame",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
+    "subtypes": [ "TOOL" ],
     "category": "weapons",
-    "name": {
-      "str": "searing blast canister"
-    },
+    "name": { "str": "searing blast canister" },
     "description": "This is a small canister with elemental energy bound to it.  Arm it to ready it for use, after which it will explode in a few seconds.  Its effect will blast the area around it with flames.  You can also opt to set it up as an explosive trap.",
     "weight": "550 g",
     "volume": "250 ml",
@@ -659,20 +343,14 @@
         "done_message": "You place the canister, primed to explode if disturbed."
       }
     ],
-    "flags": [
-      "BOMB"
-    ]
+    "flags": [ "BOMB" ]
   },
   {
     "id": "blast_canister_arcana_flame_act",
     "copy-from": "blast_canister_arcana_flame",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
-    "name": {
-      "str": "active searing blast canister"
-    },
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "active searing blast canister" },
     "description": "This is a small canister with elemental energy bound to it.  It will go off in a few seconds, blasting the area around it with flames.",
     "price_postapoc": "0 cent",
     "initial_charges": 3,
@@ -690,28 +368,17 @@
       "fields_radius": 2,
       "fields_min_intensity": 1,
       "fields_max_intensity": 2,
-      "explosion": {
-        "power": 500,
-        "distance_factor": 0.2
-      }
+      "explosion": { "power": 500, "distance_factor": 0.2 }
     },
-    "flags": [
-      "BOMB",
-      "TRADER_AVOID",
-      "NO_REPAIR",
-      "LIGHT_50"
-    ]
+    "light": 200,
+    "flags": [ "BOMB", "TRADER_AVOID", "NO_REPAIR" ]
   },
   {
     "id": "blast_canister_arcana_water",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
+    "subtypes": [ "TOOL" ],
     "category": "weapons",
-    "name": {
-      "str": "wintry blast canister"
-    },
+    "name": { "str": "wintry blast canister" },
     "description": "This is a small canister with elemental energy bound to it.  Arm it to ready it for use, after which it will explode in a few seconds.  Its effect will blast the area around it with supernatural cold.  You can also opt to set it up as an explosive trap.",
     "weight": "550 g",
     "volume": "250 ml",
@@ -738,20 +405,14 @@
         "done_message": "You place the canister, primed to explode if disturbed."
       }
     ],
-    "flags": [
-      "BOMB"
-    ]
+    "flags": [ "BOMB" ]
   },
   {
     "id": "blast_canister_arcana_water_act",
     "copy-from": "blast_canister_arcana_water",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
-    "name": {
-      "str": "active wintry blast canister"
-    },
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "active wintry blast canister" },
     "description": "This is a small canister with elemental energy bound to it.  It will go off in a few seconds, blasting the area around it with supernatural cold.",
     "price_postapoc": "0 cent",
     "initial_charges": 3,
@@ -769,28 +430,17 @@
       "fields_radius": 2,
       "fields_min_intensity": 1,
       "fields_max_intensity": 2,
-      "explosion": {
-        "power": 625,
-        "distance_factor": 0.2
-      }
+      "explosion": { "power": 625, "distance_factor": 0.2 }
     },
-    "flags": [
-      "BOMB",
-      "TRADER_AVOID",
-      "NO_REPAIR",
-      "LIGHT_50"
-    ]
+    "light": 200,
+    "flags": [ "BOMB", "TRADER_AVOID", "NO_REPAIR" ]
   },
   {
     "id": "blast_canister_arcana_earth",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
+    "subtypes": [ "TOOL" ],
     "category": "weapons",
-    "name": {
-      "str": "earthen blast canister"
-    },
+    "name": { "str": "earthen blast canister" },
     "description": "This is a small canister with elemental energy bound to it.  Arm it to ready it for use, after which it will explode in a few seconds.  Its effect will blast the area around it with acid.  You can also opt to set it up as an explosive trap.",
     "weight": "550 g",
     "volume": "250 ml",
@@ -817,20 +467,14 @@
         "done_message": "You place the canister, primed to explode if disturbed."
       }
     ],
-    "flags": [
-      "BOMB"
-    ]
+    "flags": [ "BOMB" ]
   },
   {
     "id": "blast_canister_arcana_earth_act",
     "copy-from": "blast_canister_arcana_earth",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
-    "name": {
-      "str": "active earthen blast canister"
-    },
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "active earthen blast canister" },
     "description": "This is a small canister with elemental energy bound to it.  It will go off in a few seconds, blasting the area around it with acid.",
     "price_postapoc": "0 cent",
     "initial_charges": 3,
@@ -848,28 +492,17 @@
       "fields_radius": 2,
       "fields_min_intensity": 1,
       "fields_max_intensity": 2,
-      "explosion": {
-        "power": 750,
-        "distance_factor": 0.2
-      }
+      "explosion": { "power": 750, "distance_factor": 0.2 }
     },
-    "flags": [
-      "BOMB",
-      "TRADER_AVOID",
-      "NO_REPAIR",
-      "LIGHT_50"
-    ]
+    "light": 200,
+    "flags": [ "BOMB", "TRADER_AVOID", "NO_REPAIR" ]
   },
   {
     "id": "blast_canister_arcana_air",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
+    "subtypes": [ "TOOL" ],
     "category": "weapons",
-    "name": {
-      "str": "thunderous blast canister"
-    },
+    "name": { "str": "thunderous blast canister" },
     "description": "This is a small canister with elemental energy bound to it.  Arm it to ready it for use, after which it will explode in a few seconds.  Its effect will blast the area around it with lightning.  You can also opt to set it up as an explosive trap.",
     "weight": "550 g",
     "volume": "250 ml",
@@ -896,20 +529,14 @@
         "done_message": "You place the canister, primed to explode if disturbed."
       }
     ],
-    "flags": [
-      "BOMB"
-    ]
+    "flags": [ "BOMB" ]
   },
   {
     "id": "blast_canister_arcana_air_act",
     "copy-from": "blast_canister_arcana_air",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
-    "name": {
-      "str": "active thunderous blast canister"
-    },
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "active thunderous blast canister" },
     "description": "This is a small canister with elemental energy bound to it.  It will go off in a few seconds, blasting the area around it with lightning.",
     "price_postapoc": "0 cent",
     "initial_charges": 3,
@@ -927,29 +554,17 @@
       "fields_radius": 2,
       "fields_min_intensity": 1,
       "fields_max_intensity": 2,
-      "explosion": {
-        "power": 1125,
-        "distance_factor": 0.2
-      }
+      "explosion": { "power": 1125, "distance_factor": 0.2 }
     },
-    "flags": [
-      "BOMB",
-      "TRADER_AVOID",
-      "NO_REPAIR",
-      "LIGHT_50"
-    ]
+    "light": 200,
+    "flags": [ "BOMB", "TRADER_AVOID", "NO_REPAIR" ]
   },
   {
     "id": "summon_blank",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
+    "subtypes": [ "TOOL" ],
     "copy-from": "silver_glyph",
-    "name": {
-      "str": "glyph of the root",
-      "str_pl": "glyphs of the root"
-    },
+    "name": { "str": "glyph of the root", "str_pl": "glyphs of the root" },
     "//": "ID retained to prevent tileset breakage, monster summoned was changed due to blank bodies being outright useless.",
     "description": "A strange silver emblem, engraved with depictions of alien plantlife.  Using it will call forth a triffid, and bind it to your will.  Hopefully.  It is easy to control.",
     "price": "1500 USD",
@@ -963,26 +578,16 @@
       "moves": 60,
       "place_randomly": true,
       "is_pet": true,
-      "skills": [
-        "magic"
-      ]
+      "skills": [ "magic" ]
     },
-    "flags": [
-      "NO_SALVAGE",
-      "SINGLE_USE"
-    ]
+    "flags": [ "NO_SALVAGE", "SINGLE_USE" ]
   },
   {
     "id": "summon_flaming_eye",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
+    "subtypes": [ "TOOL" ],
     "copy-from": "silver_glyph",
-    "name": {
-      "str": "glyph of Gehenna",
-      "str_pl": "glyphs of Gehenna"
-    },
+    "name": { "str": "glyph of Gehenna", "str_pl": "glyphs of Gehenna" },
     "//": "ID retained to prevent tileset breakage, monster summoned was changed due to flaming eyes being useless if friendly.",
     "description": "A strange silver emblem, engraved with a mockery of angelic figures.  Using it will call forth a flesh angel, and bind it to your will.  Hopefully.  It is somewhat easy to control.",
     "price": "1500 USD",
@@ -996,26 +601,16 @@
       "moves": 60,
       "place_randomly": true,
       "is_pet": true,
-      "skills": [
-        "magic"
-      ]
+      "skills": [ "magic" ]
     },
-    "flags": [
-      "NO_SALVAGE",
-      "SINGLE_USE"
-    ]
+    "flags": [ "NO_SALVAGE", "SINGLE_USE" ]
   },
   {
     "id": "summon_hunting_horror",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
+    "subtypes": [ "TOOL" ],
     "copy-from": "silver_glyph",
-    "name": {
-      "str": "glyph of Crawling Chaos",
-      "str_pl": "glyphs of Crawling Chaos"
-    },
+    "name": { "str": "glyph of Crawling Chaos", "str_pl": "glyphs of Crawling Chaos" },
     "//": "Explanation: In Lovecraft's work, The Crawling Chaos is one of Nyarlathotep's names, and hunting horrors are associated with him.  The success and failure messages below spell it out rather plainly.",
     "description": "A strange silver emblem, erratically engraved with indecipherable runes.  Using it will call forth a hunting horror, and bind it to your will.  Hopefully.  It is somewhat easy to control.",
     "price": "1500 USD",
@@ -1029,26 +624,16 @@
       "moves": 60,
       "place_randomly": true,
       "is_pet": true,
-      "skills": [
-        "magic"
-      ]
+      "skills": [ "magic" ]
     },
-    "flags": [
-      "NO_SALVAGE",
-      "SINGLE_USE"
-    ]
+    "flags": [ "NO_SALVAGE", "SINGLE_USE" ]
   },
   {
     "id": "summon_dark_wyrm",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
+    "subtypes": [ "TOOL" ],
     "copy-from": "silver_glyph",
-    "name": {
-      "str": "glyph of the eye",
-      "str_pl": "glyphs of the eye"
-    },
+    "name": { "str": "glyph of the eye", "str_pl": "glyphs of the eye" },
     "//": "Explanation: Petrified eyes are associated with dark wyrms due to the mine finale that features one.",
     "description": "A strange silver emblem, engraved with a serpentine motif.  Using it will call forth a dark wyrm, and bind it to your will.  It is somewhat difficult to control.",
     "price": "1500 USD",
@@ -1062,26 +647,16 @@
       "moves": 60,
       "place_randomly": true,
       "is_pet": true,
-      "skills": [
-        "magic"
-      ]
+      "skills": [ "magic" ]
     },
-    "flags": [
-      "NO_SALVAGE",
-      "SINGLE_USE"
-    ]
+    "flags": [ "NO_SALVAGE", "SINGLE_USE" ]
   },
   {
     "id": "summon_mi_go",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
+    "subtypes": [ "TOOL" ],
     "copy-from": "silver_glyph",
-    "name": {
-      "str": "glyph of Yuggoth",
-      "str_pl": "glyphs of Yuggoth"
-    },
+    "name": { "str": "glyph of Yuggoth", "str_pl": "glyphs of Yuggoth" },
     "//": "Explanation: Yuggoth is a fictional planet from Lovecraft's work, stated to have been colonized by the mi-go.",
     "description": "A strange silver emblem, engraved with depictions of strange chitinous entities.  Using it will call forth a mi-go, and bind it to your will.  Hopefully.  It is somewhat difficult to control.",
     "price": "1500 USD",
@@ -1095,26 +670,16 @@
       "moves": 60,
       "place_randomly": true,
       "is_pet": true,
-      "skills": [
-        "magic"
-      ]
+      "skills": [ "magic" ]
     },
-    "flags": [
-      "NO_SALVAGE",
-      "SINGLE_USE"
-    ]
+    "flags": [ "NO_SALVAGE", "SINGLE_USE" ]
   },
   {
     "id": "summon_jabberwock",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
+    "subtypes": [ "TOOL" ],
     "copy-from": "silver_glyph",
-    "name": {
-      "str": "glyph of the golem",
-      "str_pl": "glyphs of the golem"
-    },
+    "name": { "str": "glyph of the golem", "str_pl": "glyphs of the golem" },
     "description": "A strange silver emblem, engraved with reversed writing in an unknown language.  Using it will call forth a jabberwock, and bind it to your will.  Hopefully.  It is difficult to control.",
     "price": "1500 USD",
     "price_postapoc": "70 USD",
@@ -1127,26 +692,16 @@
       "moves": 60,
       "place_randomly": true,
       "is_pet": true,
-      "skills": [
-        "magic"
-      ]
+      "skills": [ "magic" ]
     },
-    "flags": [
-      "NO_SALVAGE",
-      "SINGLE_USE"
-    ]
+    "flags": [ "NO_SALVAGE", "SINGLE_USE" ]
   },
   {
     "id": "summon_flying_polyp",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
+    "subtypes": [ "TOOL" ],
     "copy-from": "silver_glyph",
-    "name": {
-      "str": "glyph of Pnakotus",
-      "str_pl": "glyphs of Pnakotus"
-    },
+    "name": { "str": "glyph of Pnakotus", "str_pl": "glyphs of Pnakotus" },
     "//": "Explanation: In Lovecraft's works, the Pnakotic Manuscripts were associated with the city of this name, which was overrun by flying polyps in their conflict with the species that built the city.",
     "description": "A strange silver emblem, engraved with an strange pattern resembling coral.  Using it will call forth a flying polyp, and bind it to your will.  Hopefully.  It is difficult to control.",
     "price": "1500 USD",
@@ -1160,26 +715,16 @@
       "moves": 60,
       "place_randomly": true,
       "is_pet": true,
-      "skills": [
-        "magic"
-      ]
+      "skills": [ "magic" ]
     },
-    "flags": [
-      "NO_SALVAGE",
-      "SINGLE_USE"
-    ]
+    "flags": [ "NO_SALVAGE", "SINGLE_USE" ]
   },
   {
     "id": "summon_yugg",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
+    "subtypes": [ "TOOL" ],
     "copy-from": "silver_glyph",
-    "name": {
-      "str": "glyph of Plouton",
-      "str_pl": "glyphs of Plouton"
-    },
+    "name": { "str": "glyph of Plouton", "str_pl": "glyphs of Plouton" },
     "//": "Plouton, Latinized as Pluto, is another name for Hades, and reflects the association with wealth the god had by the time the name was in common use.",
     "description": "A strange silver emblem, engraved with depictions of ancient, cthonian wealth.  Using it will call forth a yugg, and bind it to your will.  Hopefully.  It is very difficult to control.",
     "price": "1500 USD",
@@ -1193,26 +738,16 @@
       "moves": 60,
       "place_randomly": true,
       "is_pet": true,
-      "skills": [
-        "magic"
-      ]
+      "skills": [ "magic" ]
     },
-    "flags": [
-      "NO_SALVAGE",
-      "SINGLE_USE"
-    ]
+    "flags": [ "NO_SALVAGE", "SINGLE_USE" ]
   },
   {
     "id": "summon_shoggoth",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
+    "subtypes": [ "TOOL" ],
     "copy-from": "silver_glyph",
-    "name": {
-      "str": "glyph of the Elder Things",
-      "str_pl": "glyphs of the Elder Things"
-    },
+    "name": { "str": "glyph of the Elder Things", "str_pl": "glyphs of the Elder Things" },
     "//": "Explanation: The Elder Things in Lovecraft's work were the creators of shoggoths.",
     "description": "A strange silver emblem, engraved with many strange eye symbols.  Using it will call forth a shoggoth, and bind it to your will.  Hopefully.  It is very difficult to control.",
     "price": "1500 USD",
@@ -1226,25 +761,16 @@
       "moves": 60,
       "place_randomly": true,
       "is_pet": true,
-      "skills": [
-        "magic"
-      ]
+      "skills": [ "magic" ]
     },
-    "flags": [
-      "NO_SALVAGE",
-      "SINGLE_USE"
-    ]
+    "flags": [ "NO_SALVAGE", "SINGLE_USE" ]
   },
   {
     "id": "summon_triffid_bound",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
+    "subtypes": [ "TOOL" ],
     "copy-from": "summon_blank",
-    "name": {
-      "str": "bound summoned triffid"
-    },
+    "name": { "str": "bound summoned triffid" },
     "description": "A charm of living essence wrapped around what looks to be a ghostly image of a silver glyph.  A triffid has been bound into this after a successful summon, activate to redeploy it.",
     "use_action": {
       "type": "place_monster",
@@ -1258,13 +784,9 @@
   {
     "id": "summon_flesh_angel_bound",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
+    "subtypes": [ "TOOL" ],
     "copy-from": "summon_flaming_eye",
-    "name": {
-      "str": "bound summoned flesh angel"
-    },
+    "name": { "str": "bound summoned flesh angel" },
     "description": "A charm of living essence wrapped around what looks to be a ghostly image of a silver glyph.  A flesh angel has been bound into this after a successful summon, activate to redeploy it.",
     "use_action": {
       "type": "place_monster",
@@ -1278,13 +800,9 @@
   {
     "id": "summon_hunting_horror_bound",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
+    "subtypes": [ "TOOL" ],
     "copy-from": "summon_hunting_horror",
-    "name": {
-      "str": "bound summoned hunting horror"
-    },
+    "name": { "str": "bound summoned hunting horror" },
     "description": "A charm of living essence wrapped around what looks to be a ghostly image of a silver glyph.  A hunting horror has been bound into this after a successful summon, activate to redeploy it.",
     "use_action": {
       "type": "place_monster",
@@ -1298,13 +816,9 @@
   {
     "id": "summon_dark_wyrm_bound",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
+    "subtypes": [ "TOOL" ],
     "copy-from": "summon_dark_wyrm",
-    "name": {
-      "str": "bound summoned dark wyrm"
-    },
+    "name": { "str": "bound summoned dark wyrm" },
     "description": "A charm of living essence wrapped around what looks to be a ghostly image of a silver glyph.  A dark wyrm has been bound into this after a successful summon, activate to redeploy it.",
     "use_action": {
       "type": "place_monster",
@@ -1318,13 +832,9 @@
   {
     "id": "summon_mi_go_bound",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
+    "subtypes": [ "TOOL" ],
     "copy-from": "summon_mi_go",
-    "name": {
-      "str": "bound summoned mi-go"
-    },
+    "name": { "str": "bound summoned mi-go" },
     "description": "A charm of living essence wrapped around what looks to be a ghostly image of a silver glyph.  A mi-go has been bound into this after a successful summon, activate to redeploy it.",
     "use_action": {
       "type": "place_monster",
@@ -1338,13 +848,9 @@
   {
     "id": "summon_jabberwock_bound",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
+    "subtypes": [ "TOOL" ],
     "copy-from": "summon_jabberwock",
-    "name": {
-      "str": "bound summoned jabberwock"
-    },
+    "name": { "str": "bound summoned jabberwock" },
     "description": "A charm of living essence wrapped around what looks to be a ghostly image of a silver glyph.  A jabberwock has been bound into this after a successful summon, activate to redeploy it.",
     "use_action": {
       "type": "place_monster",
@@ -1358,13 +864,9 @@
   {
     "id": "summon_flying_polyp_bound",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
+    "subtypes": [ "TOOL" ],
     "copy-from": "summon_flying_polyp",
-    "name": {
-      "str": "bound summoned flying polyp"
-    },
+    "name": { "str": "bound summoned flying polyp" },
     "description": "A charm of living essence wrapped around what looks to be a ghostly image of a silver glyph.  A flying polyp has been bound into this after a successful summon, activate to redeploy it.",
     "use_action": {
       "type": "place_monster",
@@ -1378,13 +880,9 @@
   {
     "id": "summon_yugg_bound",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
+    "subtypes": [ "TOOL" ],
     "copy-from": "summon_yugg",
-    "name": {
-      "str": "bound summoned yugg"
-    },
+    "name": { "str": "bound summoned yugg" },
     "description": "A charm of living essence wrapped around what looks to be a ghostly image of a silver glyph.  A yugg has been bound into this after a successful summon, activate to redeploy it.",
     "use_action": {
       "type": "place_monster",
@@ -1398,13 +896,9 @@
   {
     "id": "summon_shoggoth_bound",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
+    "subtypes": [ "TOOL" ],
     "copy-from": "summon_shoggoth",
-    "name": {
-      "str": "bound summoned shoggoth"
-    },
+    "name": { "str": "bound summoned shoggoth" },
     "description": "A charm of living essence wrapped around what looks to be a ghostly image of a silver glyph.  A shoggoth has been bound into this after a successful summon, activate to redeploy it.",
     "use_action": {
       "type": "place_monster",
@@ -1419,39 +913,21 @@
     "id": "bloodaxe",
     "copy-from": "hatchet",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
+    "subtypes": [ "TOOL" ],
     "category": "weapons",
-    "weapon_category": [
-      "HAND_AXES"
-    ],
-    "name": {
-      "str": "veinreaver"
-    },
+    "weapon_category": [ "HAND_AXES" ],
+    "name": { "str": "veinreaver" },
     "description": "A hatchet with its axehead lightened a bit, stained the dull color of dried blood.  Using it will channel blood essence into a nasty explosion, with a considerable blast radius.",
     "price": "400 USD",
     "price_postapoc": "60 USD",
     "symbol": ";",
     "color": "brown",
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "essence_blood_type": 5
-        }
-      }
-    ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_blood_type": 5 } } ],
     "tool_ammo": "essence_blood_type",
     "weight": "707 g",
     "volume": "750 ml",
     "longest_side": "45 cm",
-    "relative": {
-      "melee_damage": {
-        "bash": -2
-      }
-    },
+    "relative": { "melee_damage": { "bash": -2 } },
     "use_action": [
       {
         "target": "bloodaxe_act",
@@ -1465,60 +941,30 @@
         "ammo_scale": 0
       }
     ],
-    "extend": {
-      "flags": [
-        "NO_SALVAGE",
-        "TRADER_KEEP_EQUIPPED"
-      ]
-    }
+    "extend": { "flags": [ "NO_SALVAGE", "TRADER_KEEP_EQUIPPED" ] }
   },
   {
     "id": "bloodaxe_act",
     "//": "Can't use copy-from because qualities refuse to be deleted, causing it to try and chop wood instead of exploding.",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
+    "subtypes": [ "TOOL" ],
     "category": "weapons",
-    "weapon_category": [
-      "HAND_AXES"
-    ],
-    "name": {
-      "str": "glowing veinreaver"
-    },
+    "weapon_category": [ "HAND_AXES" ],
+    "name": { "str": "glowing veinreaver" },
     "description": "A modified hatchet, the axehead giving off a wicked red glow.  Throwing it might be a smart idea, as you'll have little time to evade its blast.",
     "weight": "707 g",
     "volume": "750 ml",
     "longest_side": "45 cm",
     "price": "400 USD",
     "price_postapoc": "60 USD",
-    "melee_damage": {
-      "cold": 8,
-      "cut": 20
-    },
-    "thrown_damage": [
-      {
-        "damage_type": "cold",
-        "amount": 23
-      }
-    ],
-    "material": [
-      "steel",
-      "wood"
-    ],
+    "melee_damage": { "cold": 8, "cut": 20 },
+    "thrown_damage": [ { "damage_type": "cold", "amount": 23 } ],
+    "material": [ "steel", "wood" ],
     "symbol": ";",
     "looks_like": "hatchet",
     "color": "brown",
     "turns_per_charge": 1,
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "essence_blood_type": 5
-        }
-      }
-    ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_blood_type": 5 } } ],
     "tool_ammo": "essence_blood_type",
     "revert_to": "bloodaxe",
     "use_action": {
@@ -1532,35 +978,19 @@
       "fields_radius": 3,
       "fields_min_intensity": 3,
       "fields_max_intensity": 3,
-      "explosion": {
-        "power": 625,
-        "distance_factor": 0.45
-      }
+      "explosion": { "power": 625, "distance_factor": 0.45 }
     },
-    "flags": [
-      "DURABLE_MELEE",
-      "NONCONDUCTIVE",
-      "LIGHT_8",
-      "NO_SALVAGE",
-      "NO_UNLOAD",
-      "NO_RELOAD"
-    ]
+    "light": 32,
+    "flags": [ "DURABLE_MELEE", "NONCONDUCTIVE", "NO_SALVAGE", "NO_UNLOAD", "NO_RELOAD" ]
   },
   {
     "id": "shrike_misericorde",
     "looks_like": "rapier",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL",
-      "ARTIFACT"
-    ],
+    "subtypes": [ "TOOL", "ARTIFACT" ],
     "category": "weapons",
-    "weapon_category": [
-      "FENCING_WEAPONRY"
-    ],
-    "name": {
-      "str": "shrike's misericorde"
-    },
+    "weapon_category": [ "FENCING_WEAPONRY" ],
+    "name": { "str": "shrike's misericorde" },
     "description": "An ornate silver weapon featuring a thin blade and two flintlock barrels built into the guard.  Its strikes inflict victims with a deathly chill.  Activating it will transform it into a more compact form, allowing its user to load and fire it.  Its pistol form will impart a freezing effect on shots fired from it, including otherworldly damage that can bypass mundane armor, though robots and certain supernatural monsters will only suffer the bullet's normal damage.",
     "weight": "2 kg",
     "volume": "1500 ml",
@@ -1568,54 +998,15 @@
     "price": "1000 USD",
     "price_postapoc": "50 USD",
     "to_hit": 2,
-    "melee_damage": {
-      "cold": 12,
-      "stab": 24
-    },
-    "material": [
-      "steel",
-      "silver"
-    ],
+    "melee_damage": { "cold": 12, "stab": 24 },
+    "material": [ "steel", "silver" ],
     "symbol": "/",
     "color": "light_gray",
-    "tool_ammo": [
-      "flintlock"
-    ],
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "flintlock": 2
-        }
-      }
-    ],
-    "techniques": [
-      "RAPID",
-      "WBLOCK_2",
-      "PRECISE"
-    ],
-    "qualities": [
-      [
-        "CUT",
-        1
-      ],
-      [
-        "CUT_FINE",
-        1
-      ],
-      [
-        "BUTCHER",
-        9
-      ]
-    ],
-    "flags": [
-      "DURABLE_MELEE",
-      "SHEATH_SWORD",
-      "NO_SALVAGE",
-      "NO_RELOAD",
-      "NO_UNLOAD"
-    ],
+    "tool_ammo": [ "flintlock" ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "flintlock": 2 } } ],
+    "techniques": [ "RAPID", "WBLOCK_2", "PRECISE" ],
+    "qualities": [ [ "CUT", 1 ], [ "CUT_FINE", 1 ], [ "BUTCHER", 9 ] ],
+    "flags": [ "DURABLE_MELEE", "SHEATH_SWORD", "NO_SALVAGE", "NO_RELOAD", "NO_UNLOAD" ],
     "use_action": {
       "menu_text": "Fold into pistol mode",
       "type": "transform",
@@ -1643,69 +1034,32 @@
     "id": "lichhook",
     "copy-from": "khopesh",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
+    "subtypes": [ "TOOL" ],
     "category": "weapons",
-    "name": {
-      "str": "lichhook"
-    },
+    "name": { "str": "lichhook" },
     "description": "A curved bronze blade, decorated with silver and honed to an unnaturally sharp edge.  Using it will channel blood essence into ensnaring a nearby enemy in venomous tendrils, poisoning them and freezing them in place momentarily.  Robots and other creatures immune to biological damage will not suffer damage from it.",
     "longest_side": "70 cm",
     "price": "720 USD",
     "price_postapoc": "45 USD",
-    "melee_damage": {
-      "bash": 9,
-      "cut": 29
-    },
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "essence_blood_type": 8
-        }
-      }
-    ],
+    "melee_damage": { "bash": 9, "cut": 29 },
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_blood_type": 8 } } ],
     "charges_per_use": 2,
     "tool_ammo": "essence_blood_type",
-    "relative": {
-      "weight": "230g"
-    },
-    "use_action": [
-      {
-        "type": "cast_spell",
-        "spell_id": "arcana_item_lichhook",
-        "no_fail": true,
-        "need_wielding": true,
-        "level": 0
-      }
-    ],
-    "extend": {
-      "flags": [
-        "NO_SALVAGE",
-        "SHEATH_SWORD"
-      ]
-    }
+    "relative": { "weight": "230g" },
+    "use_action": [ { "type": "cast_spell", "spell_id": "arcana_item_lichhook", "no_fail": true, "need_wielding": true, "level": 0 } ],
+    "extend": { "flags": [ "NO_SALVAGE", "SHEATH_SWORD" ] }
   },
   {
     "id": "candle_warding",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
-    "name": {
-      "str": "candle of warding",
-      "str_pl": "candles of warding"
-    },
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "candle of warding", "str_pl": "candles of warding" },
     "description": "A candle with translucent wax, free of any impurities with a soothing aura about it.  It can be used to place a magical barrier, or used to project a faint light.  The barrier this item creates is tough and provides a source of fire.  Examining the barrier will let you retrieve the candle.",
     "weight": "100 g",
     "volume": "250 ml",
     "price": "80 USD",
     "price_postapoc": "40 USD",
-    "material": [
-      "essencemat"
-    ],
+    "material": [ "essencemat" ],
     "symbol": ",",
     "color": "white",
     "looks_like": "candle",
@@ -1717,33 +1071,21 @@
         "type": "transform",
         "ammo_scale": 0
       },
-      {
-        "type": "deploy_furn",
-        "furn_type": "f_candle_barrier_playermade"
-      }
+      { "type": "deploy_furn", "furn_type": "f_candle_barrier_playermade" }
     ],
-    "flags": [
-      "NO_SALVAGE"
-    ]
+    "flags": [ "NO_SALVAGE" ]
   },
   {
     "id": "candle_warding_active",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
-    "name": {
-      "str": "candle of warding (on)",
-      "str_pl": "candles of warding (on)"
-    },
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "candle of warding (on)", "str_pl": "candles of warding (on)" },
     "description": "A candle with translucent wax, free of any impurities with a soothing aura about it.  Its wick is lit with a ghostly blue flame, projecting light without heat.  It can also be used to place a tough magical barrier, also providing a source of fire.  Examining the barrier will let you retrieve the candle.",
     "weight": "100 g",
     "volume": "250 ml",
     "price": "80 USD",
     "price_postapoc": "40 USD",
-    "material": [
-      "essencemat"
-    ],
+    "material": [ "essencemat" ],
     "looks_like": "candle_lit",
     "repairs_like": "candle_warding",
     "symbol": ",",
@@ -1756,192 +1098,86 @@
         "type": "transform",
         "ammo_scale": 0
       },
-      {
-        "type": "firestarter",
-        "moves": 100
-      },
-      {
-        "type": "deploy_furn",
-        "furn_type": "f_candle_barrier_playermade"
-      }
+      { "type": "firestarter", "moves": 100 },
+      { "type": "deploy_furn", "furn_type": "f_candle_barrier_playermade" }
     ],
-    "flags": [
-      "NO_SALVAGE",
-      "LIGHT_12",
-      "FIRESTARTER"
-    ]
+    "light": 48,
+    "flags": [ "NO_SALVAGE", "FIRESTARTER" ]
   },
   {
     "id": "transmutation_crucible",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
-    "name": {
-      "str": "transmutation crucible"
-    },
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "transmutation crucible" },
     "description": "A small container made out of a polished, glassy material resembling stone.  A shimmer of precious metal occasionally appears within the surface, as though its internal structure flowed like liquid.  Deploying it will create a temporary workspace of shifting earth, providing a hard surface usable as an anvil as well as shifting stones that can assist in metalworking and alchemy.  It can be examined afterward to reclaim it.\n\nWhen deployed it provides the following:\n* Level 3 anvil quality.\n* Level 2 boiling quality.\n* Level 2 chemical making quality.\n* Level 1 containing quality.\n* Level 1 food cooking quality.\n* Level 2 clean surface quality.\n* Additionally serves as a crucible.",
     "weight": "1700 g",
     "volume": "1500 ml",
     "price": "6000 USD",
     "price_postapoc": "25 USD",
     "to_hit": -2,
-    "melee_damage": {
-      "bash": 10
-    },
-    "material": [
-      "stone",
-      "essencemat"
-    ],
+    "melee_damage": { "bash": 10 },
+    "material": [ "stone", "essencemat" ],
     "symbol": ";",
     "color": "brown",
     "looks_like": "crucible",
-    "use_action": {
-      "type": "deploy_furn",
-      "furn_type": "f_transmutation_crucible_deployed"
-    }
+    "use_action": { "type": "deploy_furn", "furn_type": "f_transmutation_crucible_deployed" }
   },
   {
     "id": "transmutation_crucible_deployed_fake",
     "sub": "crucible_clay",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
+    "subtypes": [ "TOOL" ],
     "copy-from": "fake_item",
-    "name": {
-      "str": "deployed transmutation crucible"
-    },
-    "qualities": [
-      [
-        "ANVIL",
-        3
-      ],
-      [
-        "COOK",
-        1
-      ],
-      [
-        "CHEM",
-        2
-      ],
-      [
-        "BOIL",
-        2
-      ],
-      [
-        "CONTAIN",
-        1
-      ],
-      [
-        "SURFACE",
-        2
-      ]
-    ]
+    "name": { "str": "deployed transmutation crucible" },
+    "qualities": [ [ "ANVIL", 3 ], [ "COOK", 1 ], [ "CHEM", 2 ], [ "BOIL", 2 ], [ "CONTAIN", 1 ], [ "SURFACE", 2 ] ]
   },
   {
     "id": "dimensional_warp_trap",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
-    "name": {
-      "str": "sliver of unreality",
-      "str_pl": "slivers of unreality"
-    },
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "sliver of unreality", "str_pl": "slivers of unreality" },
     "description": "A talisman of 16-pointed silver, twisted to ensnare a sharply-pointed piece of crystallized essence.  Focusing its energy like a lens, using it will rip open a gap in the Veil itself, before stablizing it into a dimensional gateway.  Examining the gate will allow you to teleport to any other such gates you come across.",
     "weight": "285 g",
     "volume": "150 ml",
     "price": "1500 USD",
     "price_postapoc": "100 USD",
-    "material": [
-      "silver",
-      "essencemat"
-    ],
+    "material": [ "silver", "essencemat" ],
     "symbol": ";",
     "color": "cyan",
-    "use_action": {
-      "type": "deploy_furn",
-      "furn_type": "f_arcana_dimension_doorway"
-    },
-    "flags": [
-      "SINGLE_USE"
-    ]
+    "use_action": { "type": "deploy_furn", "furn_type": "f_arcana_dimension_doorway" },
+    "flags": [ "SINGLE_USE" ]
   },
   {
     "id": "orb_veil",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL",
-      "ARTIFACT"
-    ],
+    "subtypes": [ "TOOL", "ARTIFACT" ],
     "category": "tools",
-    "name": {
-      "str": "orb of the veil",
-      "str_pl": "orbs of the veil"
-    },
+    "name": { "str": "orb of the veil", "str_pl": "orbs of the veil" },
     "description": "A mysterious orb made of a dark, almost glassy stone.  An eye pattern is worked into it, using gold for the irises and a diamond pupil.  It is said to represent a desire to protect the old knowledge and old ways, strengthened by a yearning for further enlightenment.  Using it will show you a vision of the surrounding area, along with other random side effects, along with attracting unwanted attention from Beyond…",
     "weight": "2000 g",
     "volume": "1 L",
     "price": "1200 USD",
     "price_postapoc": "100 USD",
     "to_hit": -2,
-    "melee_damage": {
-      "bash": 6
-    },
-    "material": [
-      "stone",
-      "gold",
-      "diamond"
-    ],
+    "melee_damage": { "bash": 6 },
+    "material": [ "stone", "gold", "diamond" ],
     "symbol": "*",
     "looks_like": "diamond",
     "color": "dark_gray",
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "essence_pure_type": 1
-        }
-      }
-    ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_pure_type": 1 } } ],
     "charges_per_use": 1,
     "tool_ammo": "essence_pure_type",
-    "use_action": [
-      {
-        "type": "cast_spell",
-        "spell_id": "arcana_item_orb_veil_mapping",
-        "no_fail": true,
-        "level": 0
-      }
-    ],
-    "flags": [
-      "NO_SALVAGE",
-      "MAGIC_FOCUS",
-      "TRADER_KEEP_EQUIPPED"
-    ],
+    "use_action": [ { "type": "cast_spell", "spell_id": "arcana_item_orb_veil_mapping", "no_fail": true, "level": 0 } ],
+    "flags": [ "NO_SALVAGE", "MAGIC_FOCUS", "TRADER_KEEP_EQUIPPED" ],
     "passive_effects": [
       {
         "has": "WIELD",
         "condition": "ALWAYS",
-        "mutations": [
-          "ARCANA_CLAIRVOYANCE_LESSER",
-          "SCHIZOPHRENIC"
-        ],
+        "mutations": [ "ARCANA_CLAIRVOYANCE_LESSER", "SCHIZOPHRENIC" ],
         "values": [
-          {
-            "value": "INTELLIGENCE",
-            "add": 4
-          },
-          {
-            "value": "PERCEPTION",
-            "add": 2
-          },
-          {
-            "value": "REGEN_MANA",
-            "multiply": 0.25
-          }
+          { "value": "INTELLIGENCE", "add": 4 },
+          { "value": "PERCEPTION", "add": 2 },
+          { "value": "REGEN_MANA", "multiply": 0.25 }
         ]
       }
     ]
@@ -1949,41 +1185,21 @@
   {
     "id": "staff_druidic",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
-    "weapon_category": [
-      "BATONS"
-    ],
-    "name": {
-      "str": "druidic staff",
-      "str_pl": "druidic staves"
-    },
+    "subtypes": [ "TOOL" ],
+    "weapon_category": [ "BATONS" ],
+    "name": { "str": "druidic staff", "str_pl": "druidic staves" },
     "description": "A short wooden staff decorated with engraved silver, depicting a mixture of exotic natural scenes and various holy symbols.  It is said to represent the instincts deep within the heart, tempered by restraint and reason.  Using it can repair and fortify items made of various plant or animal products and stone, but not more refined materials like metal or glass.",
     "weight": "1310 g",
     "volume": "2 L",
     "longest_side": "60 cm",
     "price": "800 USD",
     "price_postapoc": "90 USD",
-    "melee_damage": {
-      "bash": 12
-    },
-    "material": [
-      "wood",
-      "silver"
-    ],
+    "melee_damage": { "bash": 12 },
+    "material": [ "wood", "silver" ],
     "symbol": "/",
     "looks_like": "cudgel",
     "color": "light_gray",
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "essence_dull_type": 300
-        }
-      }
-    ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_dull_type": 300 } } ],
     "charges_per_use": 1,
     "tool_ammo": "essence_dull_type",
     "use_action": [
@@ -2029,49 +1245,28 @@
           "wool"
         ],
         "skill": "magic",
-        "clothing_mods": [
-          "arcana_birchbark_weave",
-          "arcana_tanbark_weave",
-          "arcana_willowbark_weave"
-        ]
+        "clothing_mods": [ "arcana_birchbark_weave", "arcana_tanbark_weave", "arcana_willowbark_weave" ]
       }
     ],
-    "flags": [
-      "NO_SALVAGE",
-      "MAGIC_FOCUS",
-      "TRADER_KEEP_EQUIPPED",
-      "SHEATH_SPEAR"
-    ]
+    "flags": [ "NO_SALVAGE", "MAGIC_FOCUS", "TRADER_KEEP_EQUIPPED", "SHEATH_SPEAR" ]
   },
   {
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
+    "subtypes": [ "TOOL" ],
     "id": "coalescent_converter",
-    "name": {
-      "str": "coalescent converter"
-    },
+    "name": { "str": "coalescent converter" },
     "description": "A device modified from an exotic compact reactor, inverting its original function entirely.  Using a large surge of power from any battery able to hold enough charge, it can generate crystallized essence.  The process is rather inefficient, and poses a high risk of damaging the fabric of reality.",
     "weight": "11 kg",
     "color": "light_cyan",
     "looks_like": "portal",
     "symbol": ":",
-    "material": [
-      "steel"
-    ],
-    "flags": [
-      "ALLOWS_REMOTE_USE"
-    ],
+    "material": [ "steel" ],
+    "flags": [ "ALLOWS_REMOTE_USE" ],
     "volume": "7 L",
-    "melee_damage": {
-      "bash": 5
-    },
+    "melee_damage": { "bash": 5 },
     "price": "8500 USD",
     "price_postapoc": "80 USD",
-    "tool_ammo": [
-      "battery"
-    ],
+    "tool_ammo": [ "battery" ],
     "charges_per_use": 3000,
     "pocket_data": [
       {
@@ -2080,84 +1275,46 @@
         "magazine_well": "5 L",
         "max_contains_volume": "50 L",
         "max_contains_weight": "400 kg",
-        "item_restriction": [
-          "medium_storage_battery",
-          "storage_battery",
-          "large_storage_battery"
-        ]
+        "item_restriction": [ "medium_storage_battery", "storage_battery", "large_storage_battery" ]
       }
     ],
-    "use_action": [
-      {
-        "type": "cast_spell",
-        "spell_id": "arcana_item_coalescent_conversion",
-        "no_fail": true,
-        "level": 0
-      }
-    ]
+    "use_action": [ { "type": "cast_spell", "spell_id": "arcana_item_coalescent_conversion", "no_fail": true, "level": 0 } ]
   },
   {
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
+    "subtypes": [ "TOOL" ],
     "id": "offering_chalice_coalescent",
     "sub": "offering_chalice",
-    "name": {
-      "str": "coalescent chalice"
-    },
+    "name": { "str": "coalescent chalice" },
     "description": "An exotic golden chalice, reinforced by an ornate lattice of steel and curious electronics.  A swirling, inky blackness resides inside it, resisting any attempt to pour it out.  Using it will focus your energy into it through a powerful ritual, converting it into crystallized essence.  Doing so will take 15 minutes and greatly exhaust you.  Overuse comes with the risk of lethal side effects.",
     "weight": "3 kg",
     "color": "yellow",
     "looks_like": "offering_chalice",
     "symbol": ":",
-    "material": [
-      "gold",
-      "steel"
-    ],
-    "flags": [
-      "ALLOWS_REMOTE_USE",
-      "MAGIC_FOCUS"
-    ],
+    "material": [ "gold", "steel" ],
+    "flags": [ "ALLOWS_REMOTE_USE", "MAGIC_FOCUS" ],
     "volume": "2 L",
-    "melee_damage": {
-      "bash": 3
-    },
+    "melee_damage": { "bash": 3 },
     "price": "3200 USD",
     "price_postapoc": "35 USD",
-    "use_action": [
-      {
-        "type": "cast_spell",
-        "spell_id": "arcana_item_coalescent_offering",
-        "no_fail": true,
-        "level": 0
-      }
-    ]
+    "use_action": [ { "type": "cast_spell", "spell_id": "arcana_item_coalescent_offering", "no_fail": true, "level": 0 } ]
   },
   {
     "id": "thermic_essence_cutter",
     "sub": "oxy_torch",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
-    "name": {
-      "str": "thermic essence cutter"
-    },
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "thermic essence cutter" },
     "description": "A small copper device that channels magical flame, focusing it into a white-hot pinprick of searing heat.  Too narrow in focus and short-ranged to be useful as a weapon, instead designed for metalworking and repairing items.  With a source of eye protection it can be used to destroy metal barriers.",
     "weight": "2400 g",
     "volume": "1 L",
     "price": "600 USD",
     "price_postapoc": "15 USD",
-    "material": [
-      "copper"
-    ],
+    "material": [ "copper" ],
     "looks_like": "copper_knife",
     "symbol": ";",
     "color": "red",
-    "tool_ammo": [
-      "essence_dull_type"
-    ],
+    "tool_ammo": [ "essence_dull_type" ],
     "charges_per_use": 2,
     "use_action": [
       "OXYTORCH",
@@ -2190,79 +1347,37 @@
         "move_cost": 1000
       }
     ],
-    "flags": [
-      "ALLOWS_REMOTE_USE"
-    ],
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "essence_dull_type": 300
-        }
-      }
-    ]
+    "flags": [ "ALLOWS_REMOTE_USE" ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_dull_type": 300 } } ]
   },
   {
     "id": "spatial_displacer",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
-    "name": {
-      "str": "spatial displacer"
-    },
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "spatial displacer" },
     "description": "A cutting-edge piece of dimensional science, heavily modified to incorporate refinements from Beyond.  Using it will teleport you to a targeted location, a vast improvement over the uncertainty of previous devices, even destroying any obstacles that would make emergence unsafe.  However, using it might attract unwanted attention from things that do not belong in this world…",
     "weight": "1360 g",
     "volume": "2 L",
     "price": "9000 USD",
     "price_postapoc": "15 USD",
     "to_hit": -1,
-    "melee_damage": {
-      "bash": 4
-    },
-    "material": [
-      "steel"
-    ],
+    "melee_damage": { "bash": 4 },
+    "material": [ "steel" ],
     "looks_like": "teleporter",
     "symbol": ";",
     "color": "magenta",
-    "tool_ammo": [
-      "essence_type"
-    ],
+    "tool_ammo": [ "essence_type" ],
     "charges_per_use": 1,
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "ammo_restriction": {
-          "essence_type": 20
-        },
-        "rigid": true
-      }
-    ],
-    "use_action": [
-      {
-        "type": "cast_spell",
-        "spell_id": "arcana_item_spatial_displacement",
-        "no_fail": true,
-        "level": 0
-      }
-    ]
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "essence_type": 20 }, "rigid": true } ],
+    "use_action": [ { "type": "cast_spell", "spell_id": "arcana_item_spatial_displacement", "no_fail": true, "level": 0 } ]
   },
   {
     "id": "verge_meteoric",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL",
-      "ARTIFACT"
-    ],
+    "subtypes": [ "TOOL", "ARTIFACT" ],
     "category": "weapons",
-    "weapon_category": [
-      "BATONS"
-    ],
-    "name": {
-      "str": "meteoric verge"
-    },
+    "weapon_category": [ "BATONS" ],
+    "name": { "str": "meteoric verge" },
     "description": "A short wooden staff, entirely covered in decorative motifs worked from a symbol of judgment.  The symbol's otherworldly presence is still evident in the twisted, flame-like prongs now entwined around a charm of dark, iridescent metal.  Using it will allow you to smite enemies with lightning, protecting you from electrical harm briefly as well.",
     "weight": "1585 g",
     "to_hit": 1,
@@ -2270,26 +1385,12 @@
     "longest_side": "60 cm",
     "//": "Meteoric verge and moonstone scourge require items that did not exist pre-cataclysm.",
     "price_postapoc": "150 USD",
-    "melee_damage": {
-      "bash": 16,
-      "stab": 4
-    },
-    "material": [
-      "steel",
-      "gold"
-    ],
+    "melee_damage": { "bash": 16, "stab": 4 },
+    "material": [ "steel", "gold" ],
     "symbol": "/",
     "looks_like": "i_staff",
     "color": "yellow",
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "essence_type": 10
-        }
-      }
-    ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_type": 10 } } ],
     "charges_per_use": 2,
     "tool_ammo": "essence_type",
     "use_action": [
@@ -2301,13 +1402,7 @@
         "level": 0
       }
     ],
-    "flags": [
-      "NO_SALVAGE",
-      "MAGIC_FOCUS",
-      "TRADER_KEEP_EQUIPPED",
-      "SHEATH_SPEAR",
-      "DURABLE_MELEE"
-    ],
+    "flags": [ "NO_SALVAGE", "MAGIC_FOCUS", "TRADER_KEEP_EQUIPPED", "SHEATH_SPEAR", "DURABLE_MELEE" ],
     "passive_effects": [
       {
         "has": "WIELD",
@@ -2326,49 +1421,21 @@
   {
     "id": "scourge_moonstone",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL",
-      "ARTIFACT"
-    ],
+    "subtypes": [ "TOOL", "ARTIFACT" ],
     "category": "weapons",
     "symbol": "/",
     "looks_like": "bullwhip_razor",
     "color": "dark_gray",
-    "name": {
-      "str": "moonstone scourge"
-    },
+    "name": { "str": "moonstone scourge" },
     "description": "A lash modified with razor-sharp slivers of opalescent stone, and silver decoration along the handle.  While relatively effective as a weapon, fueling it with blood essence will restore its life-draining properties, and make it a much more deadly weapon.",
     "weight": "3500 g",
     "volume": "2 L",
     "price_postapoc": "150 USD",
-    "material": [
-      "leather",
-      "stone",
-      "silver"
-    ],
-    "flags": [
-      "REACH_ATTACK",
-      "REACH3",
-      "NO_SALVAGE",
-      "TRADER_KEEP_EQUIPPED",
-      "DURABLE_MELEE"
-    ],
-    "techniques": [
-      "WHIP_DISARM"
-    ],
-    "melee_damage": {
-      "bash": 3,
-      "cut": 21
-    },
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "essence_blood_type": 24
-        }
-      }
-    ],
+    "material": [ "leather", "stone", "silver" ],
+    "flags": [ "REACH_ATTACK", "REACH3", "NO_SALVAGE", "TRADER_KEEP_EQUIPPED", "DURABLE_MELEE" ],
+    "techniques": [ "WHIP_DISARM" ],
+    "melee_damage": { "bash": 3, "cut": 21 },
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_blood_type": 24 } } ],
     "tool_ammo": "essence_blood_type",
     "use_action": [
       {
@@ -2382,44 +1449,22 @@
         "ammo_scale": 0
       }
     ],
-    "passive_effects": [
-      {
-        "has": "WIELD",
-        "condition": "ACTIVE",
-        "hit_you_effect": [
-          {
-            "id": "arcana_react_drain_life",
-            "once_in": 5
-          }
-        ]
-      }
-    ]
+    "passive_effects": [ { "has": "WIELD", "condition": "ACTIVE", "hit_you_effect": [ { "id": "arcana_react_drain_life", "once_in": 5 } ] } ]
   },
   {
     "id": "scourge_moonstone_on",
     "copy-from": "scourge_moonstone",
     "repairs_like": "scourge_moonstone",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
-    "name": {
-      "str": "moonstone scourge (on)",
-      "str_pl": "moonstone scourges (on)"
-    },
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "moonstone scourge (on)", "str_pl": "moonstone scourges (on)" },
     "description": "A lash modified with razor-sharp slivers of opalescent stone, and silver decoration along the handle.  The stone blades reflect with an eerie red luster, and it seems far more nimble in the hand.",
     "//": "Turns out that modifying attack speed via relic data doesn't work right for transforming items, so weight-based hacks it is!",
     "weight": "35 g",
     "to_hit": 2,
     "turns_per_charge": 25,
     "revert_to": "scourge_moonstone",
-    "techniques": [
-      "RAPID",
-      "SWEEP",
-      "WHIP_DISARM",
-      "SPIN",
-      "WIDE"
-    ],
+    "techniques": [ "RAPID", "SWEEP", "WHIP_DISARM", "SPIN", "WIDE" ],
     "use_action": [
       {
         "target": "scourge_moonstone",
@@ -2432,17 +1477,10 @@
   {
     "id": "moonstone_fang",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL",
-      "ARTIFACT"
-    ],
+    "subtypes": [ "TOOL", "ARTIFACT" ],
     "category": "weapons",
-    "weapon_category": [
-      "KNIVES"
-    ],
-    "name": {
-      "str": "moonstone fang"
-    },
+    "weapon_category": [ "KNIVES" ],
+    "name": { "str": "moonstone fang" },
     "description": "A short, curved spike made of a white opalescent gemstone, richly engraved with swirling serpentine imagery.  Wielding it grant a minor life-draining touch and potentially blind attackers with magic, but it can sicken body and mind.  Activating it will additionally harden the body against cold, draining essence over time.",
     "weight": "160 g",
     "volume": "1500 ml",
@@ -2450,37 +1488,16 @@
     "//": "And the third shrine item, also post-cata only.",
     "price_postapoc": "100 USD",
     "to_hit": 2,
-    "melee_damage": {
-      "bash": 3,
-      "stab": 18
-    },
-    "material": [
-      "stone"
-    ],
+    "melee_damage": { "bash": 3, "stab": 18 },
+    "material": [ "stone" ],
     "symbol": "/",
     "looks_like": "small_relic",
     "repairs_like": "blood_athame",
     "color": "dark_gray",
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "essence_type": 10
-        }
-      }
-    ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_type": 10 } } ],
     "tool_ammo": "essence_type",
-    "techniques": [
-      "RAPID",
-      "DEF_DISARM"
-    ],
-    "qualities": [
-      [
-        "BUTCHER",
-        6
-      ]
-    ],
+    "techniques": [ "RAPID", "DEF_DISARM" ],
+    "qualities": [ [ "BUTCHER", 6 ] ],
     "use_action": {
       "target": "moonstone_fang_on",
       "msg": "The carvings in the stone glow blue for a brief moment, and an uncomfortable warmth spreads through your body.",
@@ -2492,25 +1509,12 @@
       "type": "transform",
       "ammo_scale": 0
     },
-    "flags": [
-      "SHEATH_KNIFE",
-      "TRADER_KEEP_EQUIPPED",
-      "DURABLE_MELEE"
-    ],
+    "flags": [ "SHEATH_KNIFE", "TRADER_KEEP_EQUIPPED", "DURABLE_MELEE" ],
     "passive_effects": [
       {
         "has": "WIELD",
         "condition": "ALWAYS",
-        "hit_you_effect": [
-          {
-            "id": "arcana_react_drain_life",
-            "once_in": 5
-          },
-          {
-            "id": "arcana_react_moonstone_touch",
-            "once_in": 10
-          }
-        ],
+        "hit_you_effect": [ { "id": "arcana_react_drain_life", "once_in": 5 }, { "id": "arcana_react_moonstone_touch", "once_in": 10 } ],
         "hit_me_effect": [
           {
             "id": "arcana_react_shadowy_shield",
@@ -2523,33 +1527,18 @@
       {
         "has": "WIELD",
         "condition": "ACTIVE",
-        "incoming_damage_mod": [
-          {
-            "type": "cold",
-            "multiply": -0.5
-          }
-        ],
-        "ench_effects": [
-          {
-            "effect": "cold_ward",
-            "intensity": 1
-          }
-        ]
+        "incoming_damage_mod": [ { "type": "cold", "multiply": -0.5 } ],
+        "ench_effects": [ { "effect": "cold_ward", "intensity": 1 } ]
       }
     ]
   },
   {
     "id": "moonstone_fang_on",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
+    "subtypes": [ "TOOL" ],
     "copy-from": "moonstone_fang",
     "repairs_like": "moonstone_fang",
-    "name": {
-      "str": "moonstone fang (on)",
-      "str_pl": "moonstone fangs (on)"
-    },
+    "name": { "str": "moonstone fang (on)", "str_pl": "moonstone fangs (on)" },
     "description": "A short, curved spike made of a white opalescent gemstone, richly engraved with swirling serpentine imagery.  In addition to its life-draining strikes and blinding attackers, it is currently protecting you against the cold.  It can't be released until deactivated, however.",
     "turns_per_charge": 450,
     "revert_to": "moonstone_fang",
@@ -2559,26 +1548,16 @@
       "type": "transform",
       "ammo_scale": 0
     },
-    "extend": {
-      "flags": [
-        "TRADER_AVOID",
-        "NO_UNWIELD"
-      ]
-    }
+    "extend": { "flags": [ "TRADER_AVOID", "NO_UNWIELD" ] }
   },
   {
     "id": "veilblade",
     "looks_like": "zweihander",
     "copy-from": "zweihander",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL",
-      "ARTIFACT"
-    ],
+    "subtypes": [ "TOOL", "ARTIFACT" ],
     "category": "weapons",
-    "name": {
-      "str": "restored ritual blade"
-    },
+    "name": { "str": "restored ritual blade" },
     "description": "A two-handed sword richly engraved with exotic runes, all in scripts not of this world.  Once corrupted and now restored, it can only serve a fragment of its original purpose.  Linger near a portal to collapse it into a form you can harvest crystallized essence from.  Use \"consume\" to offer power to the Beyond.  It will grant great gifts, but set you down a path you can't return from.  Using \"cast spell\" instead will channel its fuel into a burst of energy, restoring 1500 mana if used on yourself …or, unravel a single nearby enemy for massive damage.",
     "weight": "2267 g",
     "volume": "3 L",
@@ -2587,37 +1566,18 @@
     "price": "90000 USD",
     "price_postapoc": "150 USD",
     "to_hit": 2,
-    "melee_damage": {
-      "bash": 15,
-      "cut": 41
-    },
-    "material": [
-      "steel",
-      "essencemat"
-    ],
+    "melee_damage": { "bash": 15, "cut": 41 },
+    "material": [ "steel", "essencemat" ],
     "symbol": "/",
     "color": "light_gray",
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "essence_pure_type": 10
-        }
-      }
-    ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_pure_type": 10 } } ],
     "charges_per_use": 1,
     "tool_ammo": "essence_pure_type",
     "use_action": [
       {
         "type": "consume_drug",
         "activation_message": "You channel a sliver of essence through the blade, as an offering to the Beyond…",
-        "effects": [
-          {
-            "id": "arcana_paragon_veilblade_effect",
-            "duration": 5
-          }
-        ]
+        "effects": [ { "id": "arcana_paragon_veilblade_effect", "duration": 5 } ]
       },
       {
         "type": "cast_spell",
@@ -2627,64 +1587,23 @@
         "level": 0
       }
     ],
-    "techniques": [
-      "WBLOCK_1",
-      "WIDE",
-      "BRUTAL",
-      "SWEEP"
-    ],
-    "flags": [
-      "UNBREAKABLE_MELEE",
-      "NO_SALVAGE",
-      "MAGIC_FOCUS",
-      "NONCONDUCTIVE",
-      "SHEATH_SWORD",
-      "TRADER_KEEP_EQUIPPED"
-    ],
+    "techniques": [ "WBLOCK_1", "WIDE", "BRUTAL", "SWEEP" ],
+    "flags": [ "UNBREAKABLE_MELEE", "NO_SALVAGE", "MAGIC_FOCUS", "NONCONDUCTIVE", "SHEATH_SWORD", "TRADER_KEEP_EQUIPPED" ],
     "passive_effects": [
       {
         "has": "WIELD",
         "condition": "ALWAYS",
-        "values": [
-          {
-            "value": "INTELLIGENCE",
-            "add": 4
-          },
-          {
-            "value": "REGEN_MANA",
-            "multiply": 0.5
-          }
-        ],
-        "ench_effects": [
-          {
-            "effect": "arcana_veilblade_halt_portal_storms",
-            "intensity": 1
-          }
-        ],
-        "intermittent_activation": {
-          "effects": [
-            {
-              "frequency": "3 minutes",
-              "spell_effects": [
-                {
-                  "id": "arcana_react_veilblade"
-                }
-              ]
-            }
-          ]
-        }
+        "values": [ { "value": "INTELLIGENCE", "add": 4 }, { "value": "REGEN_MANA", "multiply": 0.5 } ],
+        "ench_effects": [ { "effect": "arcana_veilblade_halt_portal_storms", "intensity": 1 } ],
+        "intermittent_activation": { "effects": [ { "frequency": "3 minutes", "spell_effects": [ { "id": "arcana_react_veilblade" } ] } ] }
       }
     ]
   },
   {
     "id": "draconic_heart_mutator",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
-    "name": {
-      "str": "sacramental heart"
-    },
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "sacramental heart" },
     "description": "A vibrant red chunk of petrified flesh, purified and set in an ornamental mounting like a morbid brooch.  It resonates with unnatural power, as though imbued with the essence of the creature it was cut away from.  Channeling blood essence through it will start you down the path to becoming something …else.  A path you can't return from.",
     "weight": "2500 g",
     "volume": "1 L",
@@ -2692,53 +1611,27 @@
     "price": "80000 USD",
     "price_postapoc": "120 USD",
     "to_hit": -2,
-    "melee_damage": {
-      "bash": 3
-    },
-    "material": [
-      "stone",
-      "essencemat"
-    ],
+    "melee_damage": { "bash": 3 },
+    "material": [ "stone", "essencemat" ],
     "symbol": "*",
     "looks_like": "petrified_eye",
     "color": "red",
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "essence_blood_type": 10
-        }
-      }
-    ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_blood_type": 10 } } ],
     "charges_per_use": 5,
     "tool_ammo": "essence_blood_type",
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You fuel the heart with blood essence, and feel its power resonate through you…",
-      "effects": [
-        {
-          "id": "arcana_dragonblood_sacramental_heart_effect",
-          "duration": 5
-        }
-      ]
+      "effects": [ { "id": "arcana_dragonblood_sacramental_heart_effect", "duration": 5 } ]
     }
   },
   {
     "id": "sanguine_staff_lifesbane",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL",
-      "ARTIFACT"
-    ],
+    "subtypes": [ "TOOL", "ARTIFACT" ],
     "category": "weapons",
-    "weapon_category": [
-      "QUARTERSTAVES"
-    ],
-    "name": {
-      "str": "horned staff of life's bane",
-      "str_pl": "horned staves of life's bane"
-    },
+    "weapon_category": [ "QUARTERSTAVES" ],
+    "name": { "str": "horned staff of life's bane", "str_pl": "horned staves of life's bane" },
     "description": "A wooden staff topped with a golden cage, enveloping a mass of petrified flesh from which sharp horns have grown.  The counter-argument to the Dragonblood Sacrament.  It draws energy from whatever you strike with it, fueling a protective effect that synergizes with the rituals of the silver athame.  Activating it channels a powerful life-draining beam of energy that blights the land around you.",
     "weight": "2800 g",
     "volume": "3 L",
@@ -2746,27 +1639,12 @@
     "to_hit": 2,
     "//": "Conceived of before the cataclysm but only put together post-cata.",
     "price_postapoc": "150 USD",
-    "melee_damage": {
-      "bash": 22,
-      "stab": 18
-    },
-    "material": [
-      "wood",
-      "bone",
-      "essencemat"
-    ],
+    "melee_damage": { "bash": 22, "stab": 18 },
+    "material": [ "wood", "bone", "essencemat" ],
     "symbol": "/",
     "looks_like": "scourge_staff",
     "color": "red",
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "essence_blood_type": 30
-        }
-      }
-    ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_blood_type": 30 } } ],
     "charges_per_use": 5,
     "tool_ammo": "essence_blood_type",
     "use_action": [
@@ -2778,43 +1656,24 @@
         "level": 0
       }
     ],
-    "flags": [
-      "NO_SALVAGE",
-      "MAGIC_FOCUS",
-      "SHEATH_SPEAR",
-      "UNBREAKABLE_MELEE"
-    ],
+    "flags": [ "NO_SALVAGE", "MAGIC_FOCUS", "SHEATH_SPEAR", "UNBREAKABLE_MELEE" ],
     "passive_effects": [
       {
         "has": "WIELD",
         "condition": "ALWAYS",
-        "mutations": [
-          "ARCANA_STAFF_EFFECT"
-        ],
-        "hit_you_effect": [
-          {
-            "id": "arcana_react_sanguine_staff_drain"
-          }
-        ]
+        "mutations": [ "ARCANA_STAFF_EFFECT" ],
+        "hit_you_effect": [ { "id": "arcana_react_sanguine_staff_drain" } ]
       }
     ]
   },
   {
     "id": "stormbringer",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL",
-      "ARTIFACT"
-    ],
+    "subtypes": [ "TOOL", "ARTIFACT" ],
     "copy-from": "zweihander",
-    "name": {
-      "str": "cursed blade"
-    },
+    "name": { "str": "cursed blade" },
     "description": "A two-handed sword made of a dark metal.  It is engraved with unfamiliar symbols, and a single phrase in a script you can actually read: \"neherit asheiri\"  Activating it will grant the wielder a burst of powerful, corruptive, addictive life-draining magic, but you'll be unable to let go of it until the effect wears off.",
-    "material": [
-      "steel",
-      "essencemat"
-    ],
+    "material": [ "steel", "essencemat" ],
     "//": "In this case being cursed basically halves its pre-cataclysm value, as it's no longer useful for what the Keepers used it for, and the Sanguine Order's appropriation of it had a very specific focus.",
     "weight": "2267 g",
     "volume": "3 L",
@@ -2822,20 +1681,9 @@
     "price": "45000 USD",
     "price_postapoc": "120 USD",
     "to_hit": 2,
-    "melee_damage": {
-      "bash": 15,
-      "cut": 41
-    },
+    "melee_damage": { "bash": 15, "cut": 41 },
     "color": "dark_gray",
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "essence_blood_type": 9
-        }
-      }
-    ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_blood_type": 9 } } ],
     "tool_ammo": "essence_blood_type",
     "use_action": [
       {
@@ -2850,85 +1698,29 @@
         "ammo_scale": 0
       }
     ],
-    "extend": {
-      "flags": [
-        "UNBREAKABLE_MELEE",
-        "NO_SALVAGE",
-        "TRADER_KEEP_EQUIPPED"
-      ]
-    },
-    "delete": {
-      "flags": [
-        "DURABLE_MELEE",
-        "ALWAYS_TWOHAND"
-      ]
-    },
+    "extend": { "flags": [ "UNBREAKABLE_MELEE", "NO_SALVAGE", "TRADER_KEEP_EQUIPPED" ] },
+    "delete": { "flags": [ "DURABLE_MELEE", "ALWAYS_TWOHAND" ] },
     "passive_effects": [
       {
         "has": "WIELD",
         "condition": "ACTIVE",
-        "mutations": [
-          "ARCANA_BERSERK_EFFECT"
-        ],
-        "values": [
-          {
-            "value": "STRENGTH",
-            "add": 4
-          },
-          {
-            "value": "DEXTERITY",
-            "add": 2
-          }
-        ],
-        "hit_you_effect": [
-          {
-            "id": "arcana_react_drain_life_improved"
-          }
-        ],
-        "intermittent_activation": {
-          "effects": [
-            {
-              "frequency": "3 minutes",
-              "spell_effects": [
-                {
-                  "id": "arcana_react_evil_mimic"
-                }
-              ]
-            }
-          ]
-        },
-        "ench_effects": [
-          {
-            "effect": "arcana_evil_mimic_active",
-            "intensity": 1
-          }
-        ]
+        "mutations": [ "ARCANA_BERSERK_EFFECT" ],
+        "values": [ { "value": "STRENGTH", "add": 4 }, { "value": "DEXTERITY", "add": 2 } ],
+        "hit_you_effect": [ { "id": "arcana_react_drain_life_improved" } ],
+        "intermittent_activation": { "effects": [ { "frequency": "3 minutes", "spell_effects": [ { "id": "arcana_react_evil_mimic" } ] } ] },
+        "ench_effects": [ { "effect": "arcana_evil_mimic_active", "intensity": 1 } ]
       }
     ]
   },
   {
     "id": "stormbringer_on",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL",
-      "ARTIFACT"
-    ],
+    "subtypes": [ "TOOL", "ARTIFACT" ],
     "category": "weapons",
-    "name": {
-      "str": "cursed blade (on)",
-      "str_pl": "cursed blades (on)"
-    },
+    "name": { "str": "cursed blade (on)", "str_pl": "cursed blades (on)" },
     "//": "Funny as it'd be to add the bad weather effect too, that would be a tad silly.  Also still can't use copy-from.",
     "description": "A two-handed sword, blade made of a dark metal, engraved with unfamiliar symbols.  You feel as if the blade thirsts for blood, refusing to leave your grasp until it is sated.",
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE",
-        "rigid": true,
-        "ammo_restriction": {
-          "essence_blood_type": 9
-        }
-      }
-    ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "essence_blood_type": 9 } } ],
     "turns_per_charge": 200,
     "tool_ammo": "essence_blood_type",
     "revert_to": "stormbringer",
@@ -2939,89 +1731,32 @@
     "price": "45000 USD",
     "price_postapoc": "120 USD",
     "to_hit": 2,
-    "melee_damage": {
-      "bash": 15,
-      "cut": 41,
-      "cold": 10
-    },
-    "material": [
-      "steel",
-      "essencemat"
-    ],
+    "melee_damage": { "bash": 15, "cut": 41, "cold": 10 },
+    "material": [ "steel", "essencemat" ],
     "symbol": "/",
     "looks_like": "stormbringer",
     "repairs_like": "stormbringer",
     "color": "dark_gray",
-    "techniques": [
-      "WBLOCK_1",
-      "WIDE",
-      "BRUTAL",
-      "SWEEP",
-      "tec_weapon_stormbringer_slash"
-    ],
-    "flags": [
-      "UNBREAKABLE_MELEE",
-      "NO_SALVAGE",
-      "NO_UNWIELD",
-      "NO_UNLOAD",
-      "NO_RELOAD",
-      "TRADER_KEEP_EQUIPPED"
-    ],
-    "weapon_category": [
-      "GREAT_SWORDS"
-    ],
+    "techniques": [ "WBLOCK_1", "WIDE", "BRUTAL", "SWEEP", "tec_weapon_stormbringer_slash" ],
+    "flags": [ "UNBREAKABLE_MELEE", "NO_SALVAGE", "NO_UNWIELD", "NO_UNLOAD", "NO_RELOAD", "TRADER_KEEP_EQUIPPED" ],
+    "weapon_category": [ "GREAT_SWORDS" ],
     "passive_effects": [
       {
         "has": "WIELD",
         "condition": "ACTIVE",
-        "mutations": [
-          "ARCANA_BERSERK_EFFECT"
-        ],
-        "values": [
-          {
-            "value": "STRENGTH",
-            "add": 4
-          },
-          {
-            "value": "DEXTERITY",
-            "add": 2
-          }
-        ],
-        "hit_you_effect": [
-          {
-            "id": "arcana_react_drain_life_improved"
-          }
-        ],
-        "intermittent_activation": {
-          "effects": [
-            {
-              "frequency": "3 minutes",
-              "spell_effects": [
-                {
-                  "id": "arcana_react_evil_mimic"
-                }
-              ]
-            }
-          ]
-        },
-        "ench_effects": [
-          {
-            "effect": "arcana_evil_mimic_active",
-            "intensity": 1
-          }
-        ]
+        "mutations": [ "ARCANA_BERSERK_EFFECT" ],
+        "values": [ { "value": "STRENGTH", "add": 4 }, { "value": "DEXTERITY", "add": 2 } ],
+        "hit_you_effect": [ { "id": "arcana_react_drain_life_improved" } ],
+        "intermittent_activation": { "effects": [ { "frequency": "3 minutes", "spell_effects": [ { "id": "arcana_react_evil_mimic" } ] } ] },
+        "ench_effects": [ { "effect": "arcana_evil_mimic_active", "intensity": 1 } ]
       }
     ]
   },
   {
     "id": "leather_journal",
     "type": "ITEM",
-    "subtypes": [
-      "TOOL"
-    ],
-    "name": {
-      "str": "leather journal"
-    },
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "leather journal" },
     "copy-from": "leather_journal",
     "pocket_data": [
       {

--- a/Arcana/monsters/monster_drops.json
+++ b/Arcana/monsters/monster_drops.json
@@ -193,10 +193,7 @@
     "entries": [
       { "group": "default_zombie_death_drops" },
       {
-        "distribution": [
-          { "item": "monster_fang", "prob": 75 },
-          { "item": "graboid_fang", "prob": 10 }
-        ],
+        "distribution": [ { "item": "monster_fang", "prob": 75 }, { "item": "graboid_fang", "prob": 10 } ],
         "prob": 10
       },
       { "item": "essence_blood", "count": [ 2, 4 ], "prob": 25 }
@@ -209,10 +206,7 @@
     "entries": [
       { "group": "default_zombie_death_drops" },
       {
-        "distribution": [
-          { "item": "monster_fang", "prob": 75 },
-          { "item": "graboid_fang", "prob": 10 }
-        ],
+        "distribution": [ { "item": "monster_fang", "prob": 75 }, { "item": "graboid_fang", "prob": 10 } ],
         "prob": 25
       },
       { "item": "essence_blood", "count": [ 2, 4 ], "prob": 50 }
@@ -910,10 +904,7 @@
     "entries": [
       { "group": "default_zombie_clothes" },
       {
-        "distribution": [
-          { "item": "bone_twisted", "prob": 40 },
-          { "item": "iridescent_plate", "prob": 10 }
-        ],
+        "distribution": [ { "item": "bone_twisted", "prob": 40 }, { "item": "iridescent_plate", "prob": 10 } ],
         "prob": 10
       },
       { "item": "essence_blood", "prob": 25, "count": [ 2, 4 ] }
@@ -926,10 +917,7 @@
     "entries": [
       { "group": "default_zombie_clothes" },
       {
-        "distribution": [
-          { "item": "bone_twisted", "prob": 40 },
-          { "item": "iridescent_plate", "prob": 10 }
-        ],
+        "distribution": [ { "item": "bone_twisted", "prob": 40 }, { "item": "iridescent_plate", "prob": 10 } ],
         "prob": 25
       },
       { "item": "essence_blood", "prob": 50, "count": [ 2, 4 ] }
@@ -942,10 +930,7 @@
     "entries": [
       { "group": "mon_zombie_hulk_death_drops" },
       {
-        "distribution": [
-          { "item": "bone_twisted", "prob": 40 },
-          { "item": "iridescent_plate", "prob": 10 }
-        ],
+        "distribution": [ { "item": "bone_twisted", "prob": 40 }, { "item": "iridescent_plate", "prob": 10 } ],
         "prob": 50
       },
       { "item": "essence_blood", "count": [ 2, 4 ] }
@@ -994,10 +979,7 @@
     "entries": [
       { "group": "mon_zombie_hulk_death_drops" },
       {
-        "distribution": [
-          { "item": "bone_twisted", "prob": 40 },
-          { "item": "iridescent_plate", "prob": 10 }
-        ],
+        "distribution": [ { "item": "bone_twisted", "prob": 40 }, { "item": "iridescent_plate", "prob": 10 } ],
         "prob": 50
       },
       { "item": "inflorescent_root", "prob": 25 },
@@ -1296,30 +1278,8 @@
     }
   },
   {
-    "id": "mon_feral_prepper_mace_death_drops",
-    "copy-from": "mon_feral_prepper_mace_death_drops",
-    "type": "item_group",
-    "//": "Only need to add items since we're referencing an existing itemgroup.",
-    "subtype": "collection",
-    "extend": {
-      "entries": [
-        { "item": "essence_blood", "prob": 50, "count": [ 2, 4 ] },
-        { "group": "arcana_hunt_random", "prob": 10 },
-        {
-          "distribution": [
-            { "group": "magic_tools", "prob": 50, "damage": [ 1, 4 ] },
-            { "group": "magic_items", "prob": 50, "damage": [ 1, 4 ] }
-          ],
-          "prob": 3
-        },
-        { "group": "magic_consumables", "prob": 5 },
-        { "group": "magic_books_postapoc", "prob": 15 }
-      ]
-    }
-  },
-  {
-    "id": "mon_feral_prepper_knife_death_drops",
-    "copy-from": "mon_feral_prepper_knife_death_drops",
+    "id": "mon_feral_prepper_death_drops",
+    "copy-from": "mon_feral_prepper_death_drops",
     "type": "item_group",
     "//": "Only need to add items since we're referencing an existing itemgroup.",
     "subtype": "collection",
@@ -1428,22 +1388,8 @@
     }
   },
   {
-    "id": "feral_swimmer_death_drops_kickboard",
-    "copy-from": "feral_swimmer_death_drops_kickboard",
-    "type": "item_group",
-    "//": "Adds items since we're referencing an existing itemgroup.",
-    "subtype": "collection",
-    "extend": {
-      "entries": [
-        { "item": "essence_blood", "prob": 25, "count": [ 2, 4 ] },
-        { "group": "arcana_hunt_random", "prob": 10 },
-        { "group": "magic_books_postapoc", "prob": 5 }
-      ]
-    }
-  },
-  {
-    "id": "feral_diver_death_drops_knife",
-    "copy-from": "feral_diver_death_drops_knife",
+    "id": "mon_feral_sailor_death_drops",
+    "copy-from": "mon_feral_sailor_death_drops",
     "type": "item_group",
     "//": "Adds items since we're referencing an existing itemgroup.",
     "subtype": "collection",
@@ -1495,22 +1441,6 @@
     "//": "Only need to add items since we're referencing an existing itemgroup.",
     "subtype": "collection",
     "extend": { "entries": [ { "group": "strange_zombie_death_drops", "prob": 90 } ] }
-  },
-  {
-    "id": "jackson_drops",
-    "copy-from": "jackson_drops",
-    "type": "item_group",
-    "//": "The only being without the queen flag to drop boss-level essence, also gives high odds of magical gear.  Only need to add items since we're referencing an existing itemgroup.",
-    "subtype": "collection",
-    "extend": {
-      "entries": [
-        { "group": "magic_items", "prob": 25, "damage": [ 1, 4 ] },
-        { "group": "magic_consumables", "prob": 50 },
-        { "group": "magic_books_postapoc", "prob": 75 },
-        { "group": "magic_tools", "prob": 25, "damage": [ 1, 4 ] },
-        { "item": "essence_blood", "count": [ 7, 14 ] }
-      ]
-    }
   },
   {
     "id": "marloss_yellow_drops",
@@ -1657,13 +1587,7 @@
     "type": "item_group",
     "subtype": "collection",
     "entries": [
-      {
-        "distribution": [
-          { "group": "arcana_hunt_random", "prob": 75 },
-          { "item": "bone_twisted", "prob": 5 }
-        ],
-        "prob": 10
-      },
+      { "distribution": [ { "group": "arcana_hunt_random", "prob": 75 }, { "item": "bone_twisted", "prob": 5 } ], "prob": 10 },
       { "item": "essence_blood", "count": [ 2, 4 ], "prob": 15 }
     ]
   },
@@ -1703,13 +1627,7 @@
     "subtype": "collection",
     "entries": [
       { "group": "robots", "prob": 80 },
-      {
-        "distribution": [
-          { "item": "iron_thorn", "prob": 40 },
-          { "item": "bone_twisted", "prob": 30 }
-        ],
-        "prob": 10
-      },
+      { "distribution": [ { "item": "iron_thorn", "prob": 40 }, { "item": "bone_twisted", "prob": 30 } ], "prob": 10 },
       {
         "distribution": [
           { "item": "vortex_shard", "prob": 35 },
@@ -1900,12 +1818,7 @@
       { "group": "cleansing_flame_books_postapoc", "prob": 75 },
       { "group": "cleansing_flame_books_postapoc", "prob": 50 },
       { "group": "cleansing_flame_books_postapoc", "prob": 25 },
-      {
-        "distribution": [
-          { "item": "hexenhammer", "prob": 75, "damage": [ 1, 4 ] }
-        ],
-        "prob": 75
-      }
+      { "distribution": [ { "item": "hexenhammer", "prob": 75, "damage": [ 1, 4 ] } ], "prob": 75 }
     ]
   },
   {
@@ -2050,13 +1963,7 @@
     "id": "mon_zombear_death_drops",
     "subtype": "collection",
     "entries": [
-      {
-        "distribution": [
-          { "item": "monster_fang", "prob": 50 },
-          { "item": "graboid_fang", "prob": 50 }
-        ],
-        "prob": 10
-      },
+      { "distribution": [ { "item": "monster_fang", "prob": 50 }, { "item": "graboid_fang", "prob": 50 } ], "prob": 10 },
       { "item": "essence_blood", "prob": 10, "count": [ 2, 4 ] }
     ]
   },

--- a/Arcana/monsters/monsters.json
+++ b/Arcana/monsters/monsters.json
@@ -392,7 +392,7 @@
     "death_drops": {  },
     "special_attacks": [ { "id": "ranged_pull", "cooldown": 20 }, [ "LUNGE", 10 ] ],
     "extend": { "flags": [ "SEES", "PATH_AVOID_DANGER", "PRIORITIZE_TARGETS", "PET_MOUNTABLE" ] },
-    "delete": { "flags": [ "BASHES", "GROUP_BASH", "ATTACKMON" ] }
+    "delete": { "flags": [ "BASHES", "GROUP_BASH" ] }
   },
   {
     "id": "mon_dog_skeleton_summoned",
@@ -527,7 +527,7 @@
     "special_attacks": [ { "type": "bite", "cooldown": 5 } ],
     "special_when_hit": [ "ZAPBACK", 50 ],
     "extend": { "flags": [ "PATH_AVOID_DANGER", "PRIORITIZE_TARGETS", "PET_HARNESSABLE" ] },
-    "delete": { "flags": [ "ATTACKMON" ] }
+    "delete": { "flags": [  ] }
   },
   {
     "id": "mon_hunting_horror_summoned",
@@ -565,8 +565,7 @@
     "special_attacks": [ { "id": "scratch", "damage_max_instance": [ { "damage_type": "cut", "amount": 23, "armor_multiplier": 0.8 } ] } ],
     "death_drops": "mon_bound_glyph_death_drops_universal",
     "revert_to_itype": "summon_mi_go_bound",
-    "extend": { "flags": [ "PET_HARNESSABLE" ] },
-    "delete": { "flags": [ "BASHES" ] }
+    "extend": { "flags": [ "PET_HARNESSABLE" ] }
   },
   {
     "id": "mon_flying_polyp_summoned",
@@ -585,7 +584,7 @@
     "revert_to_itype": "summon_flying_polyp_bound",
     "special_attacks": [ { "type": "bite", "cooldown": 20, "damage_max_instance": [ { "damage_type": "cold", "amount": 20 } ] } ],
     "extend": { "flags": [ "SEES", "PATH_AVOID_DANGER", "PRIORITIZE_TARGETS", "PET_HARNESSABLE" ] },
-    "delete": { "flags": [ "BASHES", "ATTACKMON" ] }
+    "delete": { "flags": [ "BASHES" ] }
   },
   {
     "id": "mon_shoggoth_summoned",

--- a/Arcana/npcs/NC_FILES.json
+++ b/Arcana/npcs/NC_FILES.json
@@ -1180,8 +1180,8 @@
     ]
   },
   {
-    "id": "NC_ARSONIST_random",
-    "copy-from": "NC_ARSONIST_random",
+    "id": "NC_ARSONIST_weapon_random",
+    "copy-from": "NC_ARSONIST_weapon_random",
     "type": "item_group",
     "extend": { "items": [ [ "bloodscourge", 1 ] ] }
   },

--- a/Arcana/overmap_and_mapgen/mapgen_lab_arcane.json
+++ b/Arcana/overmap_and_mapgen/mapgen_lab_arcane.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "mapgen",
-	"om_terrain": [ [ "lab_arcane_1_1", "lab_arcane_1_2", "lab_arcane_1_3" ], [ "lab_arcane_1_4", "lab_arcane_1_5", "lab_arcane_1_6" ] ],
+    "om_terrain": [ [ "lab_arcane_1_1", "lab_arcane_1_2", "lab_arcane_1_3" ], [ "lab_arcane_1_4", "lab_arcane_1_5", "lab_arcane_1_6" ] ],
     "weight": 1000,
     "object": {
       "rows": [
@@ -67,7 +67,7 @@
         "|": "t_strconc_wall",
         "=": "t_door_metal_locked",
         "&": "t_gates_mech_control_lab",
-        "-": "t_reinforced_door_glass_c",
+        "-": "t_laminated_door_glass_c",
         "+": "t_door_glass_frosted_lab_c",
         ">": "t_stairs_down",
         "3": "t_thconc_floor",
@@ -80,7 +80,7 @@
         "O": "t_strconc_floor",
         "T": "t_strconc_floor",
         "V": "t_strconc_floor",
-        "W": "t_reinforced_glass",
+        "W": "t_laminated_glass",
         "X": "t_door_bar_locked",
         "Y": "t_utility_light",
         "b": "t_strconc_floor",
@@ -175,7 +175,7 @@
   },
   {
     "type": "mapgen",
-	"om_terrain": [ [ "lab_arcane_2_1", "lab_arcane_2_2", "lab_arcane_2_3" ], [ "lab_arcane_2_4", "lab_arcane_2_5", "lab_arcane_2_6" ] ],
+    "om_terrain": [ [ "lab_arcane_2_1", "lab_arcane_2_2", "lab_arcane_2_3" ], [ "lab_arcane_2_4", "lab_arcane_2_5", "lab_arcane_2_6" ] ],
     "weight": 1000,
     "object": {
       "rows": [
@@ -241,7 +241,7 @@
         "=": "t_door_metal_locked",
         "+": "t_door_glass_frosted_lab_c",
         "&": "t_gates_mech_control_lab",
-        "-": "t_reinforced_door_glass_c",
+        "-": "t_laminated_door_glass_c",
         ">": "t_stairs_down",
         "<": "t_stairs_up",
         "1": "t_switchgear_s",
@@ -259,7 +259,7 @@
         "S": "t_strconc_floor",
         "T": "t_strconc_floor",
         "V": "t_strconc_floor",
-        "W": "t_reinforced_glass",
+        "W": "t_laminated_glass",
         "X": "t_door_bar_locked",
         "Y": "t_utility_light",
         "b": "t_strconc_floor",
@@ -377,7 +377,7 @@
   },
   {
     "type": "mapgen",
-	"om_terrain": [ [ "lab_arcane_3_1", "lab_arcane_3_2", "lab_arcane_3_3" ], [ "lab_arcane_3_4", "lab_arcane_3_5", "lab_arcane_3_6" ] ],
+    "om_terrain": [ [ "lab_arcane_3_1", "lab_arcane_3_2", "lab_arcane_3_3" ], [ "lab_arcane_3_4", "lab_arcane_3_5", "lab_arcane_3_6" ] ],
     "weight": 1000,
     "object": {
       "rows": [
@@ -464,7 +464,7 @@
         "R": "t_strconc_floor",
         "S": "t_strconc_floor",
         "T": "t_strconc_floor",
-        "W": "t_reinforced_glass",
+        "W": "t_laminated_glass",
         "X": "t_door_bar_locked",
         "Y": "t_utility_light",
         "b": "t_strconc_floor",
@@ -609,7 +609,7 @@
   },
   {
     "type": "mapgen",
-	"om_terrain": [ [ "lab_arcane_4_1", "lab_arcane_4_2", "lab_arcane_4_3" ], [ "lab_arcane_4_4", "lab_arcane_4_5", "lab_arcane_4_6" ] ],
+    "om_terrain": [ [ "lab_arcane_4_1", "lab_arcane_4_2", "lab_arcane_4_3" ], [ "lab_arcane_4_4", "lab_arcane_4_5", "lab_arcane_4_6" ] ],
     "weight": 1000,
     "object": {
       "rows": [
@@ -706,7 +706,7 @@
         "S": "t_strconc_floor",
         "T": "t_strconc_floor",
         "V": "t_strconc_floor",
-        "W": "t_reinforced_glass",
+        "W": "t_laminated_glass",
         "X": "t_door_bar_locked",
         "Y": "t_utility_light",
         "b": "t_strconc_floor",
@@ -797,7 +797,7 @@
         "O": { "item": "lab_magitech_general", "chance": 50, "repeat": 3 },
         "d": { "item": "office_supplies", "chance": 70, "repeat": 3 },
         "o": { "item": "oven", "chance": 50, "repeat": 2 },
-        "t": { "item": "trash"},
+        "t": { "item": "trash" },
         "s": { "item": "cleaning", "chance": 50, "repeat": 5 }
       },
       "place_loot": [
@@ -881,12 +881,12 @@
   },
   {
     "type": "mapgen",
-        "nested_mapgen_id": "lab_arcane_4_4_rads",
+    "nested_mapgen_id": "lab_arcane_4_4_rads",
     "object": { "mapgensize": [ 12, 12 ], "set": [ { "square": "radiation", "amount": 50, "x": 0, "y": 0, "x2": 0, "y2": 11 } ] }
   },
   {
     "type": "mapgen",
-        "nested_mapgen_id": "lab_arcane_4_5_rads",
+    "nested_mapgen_id": "lab_arcane_4_5_rads",
     "object": {
       "mapgensize": [ 12, 12 ],
       "set": [

--- a/Arcana/overmap_and_mapgen/mapgen_variants.json
+++ b/Arcana/overmap_and_mapgen/mapgen_variants.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "mapgen",
-	"om_terrain": "evac_center_13",
+    "om_terrain": "evac_center_13",
     "weight": 1000000,
     "object": {
       "faction_owner": [ { "id": "free_merchants", "x": [ 0, 23 ], "y": [ 0, 23 ] } ],
@@ -64,7 +64,7 @@
   },
   {
     "type": "mapgen",
-	"om_terrain": [ "church" ],
+    "om_terrain": [ "church" ],
     "weight": 200,
     "object": {
       "fill_ter": "t_floor",
@@ -105,7 +105,7 @@
   },
   {
     "type": "mapgen",
-        "nested_mapgen_id": "arcana_church_ne_1",
+    "nested_mapgen_id": "arcana_church_ne_1",
     "object": {
       "mapgensize": [ 3, 3 ],
       "place_loot": [
@@ -118,7 +118,7 @@
   },
   {
     "type": "mapgen",
-        "nested_mapgen_id": "arcana_church_ne_2",
+    "nested_mapgen_id": "arcana_church_ne_2",
     "object": {
       "mapgensize": [ 3, 3 ],
       "place_loot": [
@@ -130,7 +130,7 @@
   },
   {
     "type": "mapgen",
-	"om_terrain": [ "church_1" ],
+    "om_terrain": [ "church_1" ],
     "weight": 300,
     "object": {
       "fill_ter": "t_rock_floor",
@@ -184,7 +184,7 @@
   },
   {
     "type": "mapgen",
-        "nested_mapgen_id": "arcana_church_goth_1",
+    "nested_mapgen_id": "arcana_church_goth_1",
     "object": {
       "mapgensize": [ 4, 4 ],
       "place_loot": [
@@ -197,7 +197,7 @@
   },
   {
     "type": "mapgen",
-        "nested_mapgen_id": "arcana_church_goth_2",
+    "nested_mapgen_id": "arcana_church_goth_2",
     "object": {
       "mapgensize": [ 4, 4 ],
       "place_loot": [
@@ -209,7 +209,7 @@
   },
   {
     "type": "mapgen",
-	"om_terrain": "church_3rdfloor_1",
+    "om_terrain": "church_3rdfloor_1",
     "weight": 300,
     "object": {
       "fill_ter": "t_floor",
@@ -285,7 +285,7 @@
   },
   {
     "type": "mapgen",
-	"om_terrain": [ "s_bookstore" ],
+    "om_terrain": [ "s_bookstore" ],
     "weight": 250,
     "object": {
       "fill_ter": "t_floor",
@@ -387,14 +387,12 @@
         { "item": "money_bundle_twenty", "x": [ 16, 17 ], "y": 19, "chance": 30, "repeat": 4 },
         { "item": "CF_golden_scale", "x": [ 16, 17 ], "y": 19, "chance": 30 }
       ],
-      "place_monster": [
-        { "monster": "mon_zombie_shady", "x": 9, "y": 19, "repeat": [ 1, 3 ] }
-      ]
+      "place_monster": [ { "monster": "mon_zombie_shady", "x": 9, "y": 19, "repeat": [ 1, 3 ] } ]
     }
   },
   {
     "type": "mapgen",
-	"om_terrain": [ "s_bookstore_1" ],
+    "om_terrain": [ "s_bookstore_1" ],
     "weight": 250,
     "object": {
       "fill_ter": "t_floor",
@@ -480,14 +478,12 @@
         { "item": "money_bundle_twenty", "x": [ 5, 6 ], "y": [ 19, 20 ], "chance": 30, "repeat": 4 },
         { "item": "CF_golden_scale", "x": [ 5, 6 ], "y": [ 19, 20 ], "chance": 30 }
       ],
-      "place_monster": [
-        { "monster": "mon_zombie_shady", "x": 15, "y": 14, "repeat": [ 1, 3 ] }
-      ]
+      "place_monster": [ { "monster": "mon_zombie_shady", "x": 15, "y": 14, "repeat": [ 1, 3 ] } ]
     }
   },
   {
     "type": "mapgen",
-	"om_terrain": [ "s_bookstore_2" ],
+    "om_terrain": [ "s_bookstore_2" ],
     "weight": 1500,
     "object": {
       "fill_ter": "t_floor",
@@ -602,14 +598,12 @@
         { "item": "money_bundle_twenty", "x": 14, "y": 20, "chance": 30, "repeat": 4 },
         { "item": "CF_golden_scale", "x": 14, "y": 20, "chance": 30 }
       ],
-      "place_monster": [
-        { "monster": "mon_zombie_shady", "x": 13, "y": 15, "repeat": [ 1, 3 ] }
-      ]
+      "place_monster": [ { "monster": "mon_zombie_shady", "x": 13, "y": 15, "repeat": [ 1, 3 ] } ]
     }
   },
   {
     "type": "mapgen",
-	"om_terrain": [ "mortuary" ],
+    "om_terrain": [ "mortuary" ],
     "weight": 80,
     "object": {
       "fill_ter": "t_floor",
@@ -708,7 +702,7 @@
   },
   {
     "type": "mapgen",
-	"om_terrain": [ "abstorefront_1" ],
+    "om_terrain": [ "abstorefront_1" ],
     "object": {
       "fill_ter": "t_floor",
       "rows": [
@@ -781,7 +775,7 @@
   },
   {
     "type": "mapgen",
-        "nested_mapgen_id": "abstorefront_1_spawns",
+    "nested_mapgen_id": "abstorefront_1_spawns",
     "object": {
       "mapgensize": [ 24, 24 ],
       "set": [
@@ -801,7 +795,7 @@
   },
   {
     "type": "mapgen",
-	"om_terrain": [ "house_arcana" ],
+    "om_terrain": [ "house_arcana" ],
     "weight": 300,
     "object": {
       "fill_ter": "t_floor",
@@ -902,7 +896,7 @@
   },
   {
     "type": "mapgen",
-	"om_terrain": [ "house_arcana_roof" ],
+    "om_terrain": [ "house_arcana_roof" ],
     "weight": 300,
     "object": {
       "fill_ter": "t_open_air",
@@ -938,7 +932,7 @@
   },
   {
     "type": "mapgen",
-        "nested_mapgen_id": "house_arcana_encounter_1",
+    "nested_mapgen_id": "house_arcana_encounter_1",
     "//": "Formerly inhabited by a non-faction arcanist, one way or another they never came back...",
     "object": {
       "mapgensize": [ 24, 24 ],
@@ -947,7 +941,7 @@
   },
   {
     "type": "mapgen",
-        "nested_mapgen_id": "house_arcana_encounter_2",
+    "nested_mapgen_id": "house_arcana_encounter_2",
     "//": "Generic but not very friendly arcanists lived here.  This ended about as well as expected.",
     "object": {
       "mapgensize": [ 24, 24 ],
@@ -978,7 +972,7 @@
   },
   {
     "type": "mapgen",
-        "nested_mapgen_id": "house_arcana_encounter_3",
+    "nested_mapgen_id": "house_arcana_encounter_3",
     "//": "Raid!  Similar layout as encounter number 2, but the Cleansing Flame got here first.  They didn't have time to clean up and finish looting, though.",
     "object": {
       "mapgensize": [ 24, 24 ],
@@ -1033,7 +1027,7 @@
   },
   {
     "type": "mapgen",
-	"om_terrain": [ "house_arcana_2" ],
+    "om_terrain": [ "house_arcana_2" ],
     "weight": 300,
     "object": {
       "fill_ter": "t_floor",
@@ -1135,7 +1129,7 @@
   },
   {
     "type": "mapgen",
-	"om_terrain": [ "house_arcana_roof_2" ],
+    "om_terrain": [ "house_arcana_roof_2" ],
     "weight": 300,
     "object": {
       "fill_ter": "t_open_air",
@@ -1171,7 +1165,7 @@
   },
   {
     "type": "mapgen",
-        "nested_mapgen_id": "house_arcana_encounter_4",
+    "nested_mapgen_id": "house_arcana_encounter_4",
     "//": "A mage hunter trapped themselves after being followed by ...something.",
     "object": {
       "mapgensize": [ 24, 24 ],
@@ -1200,7 +1194,7 @@
   },
   {
     "type": "mapgen",
-	"om_terrain": [ "microlab_sub_station" ],
+    "om_terrain": [ "microlab_sub_station" ],
     "weight": 125,
     "object": {
       "fill_ter": "t_concrete",
@@ -1246,7 +1240,7 @@
   {
     "type": "mapgen",
     "nested_mapgen_id": "microlab_generic_tile",
-        "object": {
+    "object": {
       "mapgensize": [ 24, 24 ],
       "rows": [
         "     |    |  2    | ccc ",
@@ -1296,7 +1290,7 @@
   {
     "//": "7x7 workstation with chance of magitech-related materials.",
     "type": "mapgen",
-        "nested_mapgen_id": "lab_room_7x7_rare",
+    "nested_mapgen_id": "lab_room_7x7_rare",
     "object": {
       "mapgensize": [ 7, 7 ],
       "rotation": [ 0, 3 ],
@@ -1337,7 +1331,7 @@
   {
     "//": "9x9 workstation with sealed storage for magic stuff.",
     "type": "mapgen",
-        "nested_mapgen_id": "lab_room_9x9_rare",
+    "nested_mapgen_id": "lab_room_9x9_rare",
     "object": {
       "mapgensize": [ 9, 9 ],
       "rotation": [ 0, 3 ],
@@ -1393,7 +1387,7 @@
   },
   {
     "type": "mapgen",
-        "nested_mapgen_id": "roof_4x4_survivor",
+    "nested_mapgen_id": "roof_4x4_survivor",
     "object": {
       "mapgensize": [ 4, 4 ],
       "place_furniture": [ { "furn": "f_camp_chair", "x": 0, "y": 0 }, { "furn": "f_makeshift_bed", "x": 2, "y": 0 } ],
@@ -1420,7 +1414,7 @@
   },
   {
     "type": "mapgen",
-        "nested_mapgen_id": "roof_6x6_survivor",
+    "nested_mapgen_id": "roof_6x6_survivor",
     "object": {
       "mapgensize": [ 6, 6 ],
       "rotation": [ 0, 3 ],
@@ -1462,7 +1456,7 @@
     }
   },
   {
-	"om_terrain": "urban_18_8",
+    "om_terrain": "urban_18_8",
     "type": "mapgen",
     "weight": 500,
     "object": {
@@ -1509,7 +1503,7 @@
   },
   {
     "type": "mapgen",
-	"om_terrain": [ "s_antique" ],
+    "om_terrain": [ "s_antique" ],
     "weight": 250,
     "object": {
       "fill_ter": "t_floor",
@@ -1581,7 +1575,7 @@
   },
   {
     "type": "mapgen",
-	"om_terrain": [ "museum" ],
+    "om_terrain": [ "museum" ],
     "weight": 500,
     "object": {
       "fill_ter": "t_floor",
@@ -1679,7 +1673,7 @@
   },
   {
     "type": "mapgen",
-	"om_terrain": [ "s_electronics" ],
+    "om_terrain": [ "s_electronics" ],
     "weight": 75,
     "object": {
       "fill_ter": "t_linoleum_gray",
@@ -1790,7 +1784,7 @@
   },
   {
     "type": "mapgen",
-	"om_terrain": [ "lab_finale_1level" ],
+    "om_terrain": [ "lab_finale_1level" ],
     "weight": 100,
     "object": {
       "rotation": [ 0, 3 ],
@@ -1914,7 +1908,7 @@
   },
   {
     "type": "mapgen",
-	"om_terrain": [ "s_library" ],
+    "om_terrain": [ "s_library" ],
     "weight": 125,
     "object": {
       "fill_ter": "t_floor",
@@ -1972,7 +1966,7 @@
   },
   {
     "type": "mapgen",
-	"om_terrain": [ "s_library_1" ],
+    "om_terrain": [ "s_library_1" ],
     "weight": 125,
     "object": {
       "fill_ter": "t_floor",
@@ -2031,7 +2025,7 @@
   },
   {
     "type": "mapgen",
-	"om_terrain": [ "s_library_2" ],
+    "om_terrain": [ "s_library_2" ],
     "weight": 250,
     "object": {
       "fill_ter": "t_floor",
@@ -2092,7 +2086,7 @@
   },
   {
     "type": "mapgen",
-	"om_terrain": [ "house_library" ],
+    "om_terrain": [ "house_library" ],
     "weight": 100,
     "object": {
       "fill_ter": "t_floor",
@@ -2166,7 +2160,7 @@
   {
     "type": "mapgen",
     "om_terrain": [ [ "microlab_arcana_surface" ] ],
-        "object": {
+    "object": {
       "fill_ter": "t_concrete",
       "rows": [
         " _______________________",
@@ -2216,7 +2210,7 @@
   },
   {
     "type": "mapgen",
-	"om_terrain": [ "microlab_arcana_rock_connector" ],
+    "om_terrain": [ "microlab_arcana_rock_connector" ],
     "weight": 1000,
     "object": {
       "fill_ter": "t_concrete",
@@ -2252,7 +2246,7 @@
   {
     "type": "mapgen",
     "om_terrain": [ "microlab_arcana_surface_connector" ],
-        "object": {
+    "object": {
       "fill_ter": "t_strconc_floor",
       "rows": [
         "     |    |  |cccc|     ",
@@ -2297,7 +2291,7 @@
   {
     "type": "mapgen",
     "om_terrain": [ [ "microlab_arcana_server_room" ] ],
-        "object": {
+    "object": {
       "fill_ter": "t_strconc_floor",
       "rows": [
         " cc c|c  c|  | cc |     ",
@@ -2350,7 +2344,7 @@
   },
   {
     "type": "mapgen",
-	"om_terrain": [ "arcana_warehouse_lab" ],
+    "om_terrain": [ "arcana_warehouse_lab" ],
     "weight": 500,
     "object": {
       "fill_ter": "t_thconc_floor",
@@ -2391,7 +2385,7 @@
         "&": "t_gates_mech_control",
         "3": "t_gutter_downspout",
         "F": "t_chainfence",
-        "W": "t_reinforced_glass",
+        "W": "t_laminated_glass",
         "f": "t_chaingate_l"
       },
       "furniture": {
@@ -2434,7 +2428,7 @@
   },
   {
     "type": "mapgen",
-	"om_terrain": "arcana_warehouse_lab_roof",
+    "om_terrain": "arcana_warehouse_lab_roof",
     "object": {
       "fill_ter": "t_tar_flat_roof",
       "rows": [
@@ -2469,7 +2463,7 @@
   },
   {
     "type": "mapgen",
-	"om_terrain": [ "arcana_cave_caravan" ],
+    "om_terrain": [ "arcana_cave_caravan" ],
     "weight": 1000,
     "object": {
       "rows": [
@@ -2529,7 +2523,7 @@
   },
   {
     "type": "mapgen",
-	"om_terrain": [ "arcana_cave_caravan_underground" ],
+    "om_terrain": [ "arcana_cave_caravan_underground" ],
     "weight": 1000,
     "object": {
       "rows": [
@@ -2570,10 +2564,7 @@
       },
       "furniture": { "%": "f_rubble_rock", "b": "f_boulder_small", "c": "f_camp_chair", "t": "f_tourist_table" },
       "mapping": {
-        ".": {
-          "item": [ { "item": "bone_human", "chance": 10 } ],
-          "items": [ { "item": "casings", "chance": 5 } ]
-        },
+        ".": { "item": [ { "item": "bone_human", "chance": 10 } ], "items": [ { "item": "casings", "chance": 5 } ] },
         "%": { "item": [ { "item": "rock", "repeat": [ 1, 5 ] } ] }
       },
       "place_loot": [
@@ -2587,7 +2578,7 @@
   },
   {
     "type": "mapgen",
-	"om_terrain": [ "pawn" ],
+    "om_terrain": [ "pawn" ],
     "weight": 100,
     "object": {
       "fill_ter": "t_floor",
@@ -2629,7 +2620,7 @@
         "|": "t_wall_y",
         "-": "t_wall_y",
         "~": "t_window_alarm",
-        "%": "t_reinforced_glass",
+        "%": "t_laminated_glass",
         "4": "t_gutter_downspout",
         "<": "t_ladder_up"
       },
@@ -2671,7 +2662,7 @@
   },
   {
     "type": "mapgen",
-	"om_terrain": [ "pawn_1" ],
+    "om_terrain": [ "pawn_1" ],
     "weight": 100,
     "object": {
       "fill_ter": "t_floor",
@@ -2761,7 +2752,7 @@
   },
   {
     "type": "mapgen",
-	"om_terrain": [ "cave_underground" ],
+    "om_terrain": [ "cave_underground" ],
     "weight": 250,
     "object": {
       "rotation": [ 0, 3 ],
@@ -2810,7 +2801,7 @@
   },
   {
     "type": "mapgen",
-        "nested_mapgen_id": "arcana_cave_underground_1",
+    "nested_mapgen_id": "arcana_cave_underground_1",
     "object": {
       "mapgensize": [ 7, 7 ],
       "rows": [
@@ -2825,18 +2816,13 @@
       "palettes": [ "arcana_palette" ],
       "items": { "~": { "item": "magic_crafting", "chance": 25 } },
       "place_monster": [
-        {
-          "monster": [ "mon_chud", "mon_twisted_body", "mon_human_snail" ],
-          "x": [ 0, 4 ],
-          "y": [ 1, 5 ],
-          "repeat": [ 1, 2 ]
-        }
+        { "monster": [ "mon_chud", "mon_twisted_body", "mon_human_snail" ], "x": [ 0, 4 ], "y": [ 1, 5 ], "repeat": [ 1, 2 ] }
       ]
     }
   },
   {
     "type": "mapgen",
-        "nested_mapgen_id": "arcana_cave_underground_2",
+    "nested_mapgen_id": "arcana_cave_underground_2",
     "object": {
       "mapgensize": [ 7, 7 ],
       "rows": [
@@ -2851,14 +2837,12 @@
       "palettes": [ "arcana_palette" ],
       "items": { ".": [ { "item": "magic_crafting", "chance": 25 } ] },
       "place_loot": [ { "item": "chunk_sulfur", "x": [ 0, 4 ], "y": [ 1, 5 ], "chance": 50, "repeat": 4 } ],
-      "place_monster": [
-        { "monster": [ "mon_blank", "mon_gozu" ], "x": [ 0, 4 ], "y": [ 1, 5 ], "repeat": [ 1, 2 ] }
-      ]
+      "place_monster": [ { "monster": [ "mon_blank", "mon_gozu" ], "x": [ 0, 4 ], "y": [ 1, 5 ], "repeat": [ 1, 2 ] } ]
     }
   },
   {
     "type": "mapgen",
-        "nested_mapgen_id": "arcana_cave_underground_3",
+    "nested_mapgen_id": "arcana_cave_underground_3",
     "object": {
       "mapgensize": [ 7, 7 ],
       "rows": [
@@ -2885,7 +2869,7 @@
   },
   {
     "type": "mapgen",
-        "nested_mapgen_id": "arcana_cave_underground_4",
+    "nested_mapgen_id": "arcana_cave_underground_4",
     "object": {
       "mapgensize": [ 7, 7 ],
       "rows": [
@@ -2911,7 +2895,7 @@
     }
   },
   {
-	"om_terrain": "desolatebarn",
+    "om_terrain": "desolatebarn",
     "type": "mapgen",
     "weight": 100,
     "object": {
@@ -2974,7 +2958,7 @@
   },
   {
     "type": "mapgen",
-	"om_terrain": [ "cabin" ],
+    "om_terrain": [ "cabin" ],
     "weight": 200,
     "object": {
       "fill_ter": "t_floor",
@@ -3021,7 +3005,7 @@
   },
   {
     "type": "mapgen",
-	"om_terrain": [ "cabin_1" ],
+    "om_terrain": [ "cabin_1" ],
     "weight": 200,
     "object": {
       "fill_ter": "t_floor",
@@ -3082,7 +3066,7 @@
   },
   {
     "type": "mapgen",
-	"om_terrain": [ "cabin_2" ],
+    "om_terrain": [ "cabin_2" ],
     "weight": 125,
     "object": {
       "fill_ter": "t_floor",
@@ -3130,7 +3114,7 @@
     }
   },
   {
-	"om_terrain": "cabin_3",
+    "om_terrain": "cabin_3",
     "type": "mapgen",
     "weight": 150,
     "object": {
@@ -3190,7 +3174,7 @@
     }
   },
   {
-	"om_terrain": "cabin_4",
+    "om_terrain": "cabin_4",
     "type": "mapgen",
     "weight": 150,
     "object": {
@@ -3253,7 +3237,7 @@
     }
   },
   {
-	"om_terrain": "cabin_5",
+    "om_terrain": "cabin_5",
     "type": "mapgen",
     "weight": 150,
     "object": {
@@ -3314,7 +3298,7 @@
     }
   },
   {
-	"om_terrain": "cabin_6",
+    "om_terrain": "cabin_6",
     "type": "mapgen",
     "weight": 150,
     "object": {
@@ -3372,7 +3356,7 @@
     }
   },
   {
-	"om_terrain": "cabin_7",
+    "om_terrain": "cabin_7",
     "type": "mapgen",
     "weight": 150,
     "object": {
@@ -3438,7 +3422,7 @@
   {
     "type": "mapgen",
     "om_terrain": "riverside_dwelling",
-        "weight": 100,
+    "weight": 100,
     "object": {
       "rows": [
         "........._........_.....",
@@ -3499,7 +3483,7 @@
   {
     "type": "mapgen",
     "om_terrain": "riverside_dwelling",
-        "weight": 75,
+    "weight": 75,
     "object": {
       "rows": [
         "......._......_._._.....",

--- a/Arcana/overmap_and_mapgen/regional_overlay.json
+++ b/Arcana/overmap_and_mapgen/regional_overlay.json
@@ -1,8 +1,9 @@
 [
   {
-    "type": "region_overlay",
-    "regions": [ "all" ],
-    "city": { "houses": { "house_arcana": 120, "house_arcana_2": 80 } }
+    "type": "region_settings_city",
+    "id": "default",
+    "copy-from": "default",
+    "extend": { "houses": [ [ "house_arcana", 120 ], [ "house_arcana_2", 80 ] ] }
   },
   {
     "type": "city_building",


### PR DESCRIPTION
Fixes the following errors for me from CTLG 1.0 2026-04-14-2032
- `reinforced_glass` -> `laminated_glass`
- use string mass for transmutation crucible
- fixes tools to use new "light" property instead of flag
- changes city overlay stuff to work (I think)
- migrated changed item_groups where I found a similar result, removes some I couldn't find.
- removes removing `"ATTACKMON"` flag from some summons for whom `"ATTACKMON"` didn't exist on the base monster anymore

Note that one debug error remains:
```
 DEBUG : In mapgen arcana_hermitage_roof, nested mapgen roof_6x6_greenhouse_1 (size 6x6) placed at (6-6, 10-10) sets terrain at (6, 10) which overlaps with furniture.  Add a clearing flag (e.g. ERASE_FURNITURE_BEFORE_PLACING_TERRAIN) to the nested mapgen, or move the furniture.

 REPORTING FUNCTION : auto jmapgen_objects::check_nested_overlaps(const std::string &, const mapgen_parameters &, const std::set<point_rel_ms> &, const terrain_coord_map &, const mapgen_value<ter_id> *)::(anonymous class)::operator()(const weighted_dbl_or_var_list<mapgen_value<nested_mapgen_id>> &) const
 C++ SOURCE FILE    : src/mapgen.cpp
 LINE               : 6048
 VERSION            : unknown
```

I also ran changed files through the autolinter, which did create some noise. Let me know if that's unacceptable and I'll do my best to restore original formatting.